### PR TITLE
Fix npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,13 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
+      - name: Get the tag name
+        id: get_tag
+        run: |
+          tag=$(echo ${GITHUB_REF/refs\/tags\//} | cut -c 2-)
+          tag=$([[ $tag =~ ^[0-9]+.[0-9]+.[0-9]+$ ]] && echo latest || echo $tag)
+          echo ::set-output name=TAG::$tag
+        shell: bash
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
@@ -20,6 +27,6 @@ jobs:
       - name: Publish to npm
         run: |
           npm ci
-          npm publish
+          npm publish --tag ${{ steps.get_tag.outputs.TAG }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
           registry-url: 'https://registry.npmjs.org'
       - name: Publish to npm
         run: |


### PR DESCRIPTION
Not sure how to properly test it the workflow, but I tried the scripts on my computer and they seems to work:

```console
➜ tag=$(echo v1.2.3 | cut -c 2-)
➜ tag=$([[ $tag =~ ^[0-9]+.[0-9]+.[0-9]+$ ]] && echo latest || echo $tag)
➜ echo $tag
latest

➜ tag=$(echo v1.2.3-rc0 | cut -c 2-)
➜ tag=$([[ $tag =~ ^[0-9]+.[0-9]+.[0-9]+$ ]] && echo latest || echo $tag)
➜ echo $tag
1.2.3-rc0
```