### PR TITLE
Update NPM release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,8 +5,10 @@ on:
     tags: ['v[0-9]+.[0-9]+.[0-9]+*']
 
 jobs:
-  build:
+  get_dist_tag:
     runs-on: ubuntu-latest
+    outputs:
+      DIST_TAG: ${{ steps.get_tag.outputs.DIST_TAG }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -16,9 +18,20 @@ jobs:
         id: get_tag
         run: |
           tag=$(echo ${GITHUB_REF/refs\/tags\//} | cut -c 2-)
-          dist_tag=$([[ $tag =~ ^[0-9]+.[0-9]+.[0-9]+$ ]] && echo latest || echo rc)
+          dist_tag=$([[ $tag =~ ^[0-9]+.[0-9]+.[0-9]+$ ]] && echo latest || echo "")
+          dist_tag=$([[ $tag =~ ^[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+$ ]] && echo rc || echo $dist_tag)
+          [ -z "$dist_tag" ] && echo "Distribution tag is not set to latest nor to rc" && exit 1
           echo ::set-output name=DIST_TAG::$dist_tag
         shell: bash
+  publish:
+    needs: get_dist_tag
+    if: needs.get_dist_tag.outputs.DIST_TAG
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
@@ -27,6 +40,6 @@ jobs:
       - name: Publish to npm
         run: |
           npm ci
-          npm publish --access public --tag ${{ steps.get_tag.outputs.DIST_TAG }}
+          npm publish --access public --tag ${{ needs.get_dist_tag.outputs.DIST_TAG }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   push:
-    tags: [ "v[0-9]+.[0-9]+.[0-9]+*" ]
+    tags: ['v[0-9]+.[0-9]+.[0-9]+*']
 
 jobs:
   build:
@@ -16,8 +16,8 @@ jobs:
         id: get_tag
         run: |
           tag=$(echo ${GITHUB_REF/refs\/tags\//} | cut -c 2-)
-          tag=$([[ $tag =~ ^[0-9]+.[0-9]+.[0-9]+$ ]] && echo latest || echo $tag)
-          echo ::set-output name=TAG::$tag
+          dist_tag=$([[ $tag =~ ^[0-9]+.[0-9]+.[0-9]+$ ]] && echo latest || echo rc)
+          echo ::set-output name=DIST_TAG::$dist_tag
         shell: bash
       - name: Use Node.js
         uses: actions/setup-node@v1
@@ -27,6 +27,6 @@ jobs:
       - name: Publish to npm
         run: |
           npm ci
-          npm publish --tag ${{ steps.get_tag.outputs.TAG }}
+          npm publish --access public --tag ${{ steps.get_tag.outputs.DIST_TAG }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   push:
-    tags: ['v[0-9]+.[0-9]+.[0-9]+*']
+    tags: ['v[0-9]+.[0-9]+.[0-9]+.*']
 
 jobs:
   get_dist_tag:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   push:
-    tags: ['v[0-9]+.[0-9]+.[0-9]+.*']
+    tags: ['v[0-9]+\.[0-9]+\.[0-9]+.*']
 
 jobs:
   get_dist_tag:
@@ -18,8 +18,8 @@ jobs:
         id: get_tag
         run: |
           tag=$(echo ${GITHUB_REF/refs\/tags\//} | cut -c 2-)
-          dist_tag=$([[ $tag =~ ^[0-9]+.[0-9]+.[0-9]+$ ]] && echo latest || echo "")
-          dist_tag=$([[ $tag =~ ^[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+$ ]] && echo rc || echo $dist_tag)
+          dist_tag=$([[ $tag =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && echo latest || echo "")
+          dist_tag=$([[ $tag =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]] && echo rc || echo $dist_tag)
           [ -z "$dist_tag" ] && echo "Distribution tag is not set to latest nor to rc" && exit 1
           echo ::set-output name=DIST_TAG::$dist_tag
         shell: bash

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npx @alephium/sdk [name]
 
 ## Install
 
-```
+```shell
 npm install @alephium/sdk
 ```
 
@@ -46,19 +46,21 @@ npm run update-schemas
 
 To release a new version:
 
-1. Create a commit that updates the package version in package.json and package-lock.json and a `vX.Y.Z` tag with:
-   ```
-   npm version X.Y.Z
+1. Create a commit that updates the package version in package.json and package-lock.json and a tag with:
+   ```shell
+   npm version patch # if you want to bump the patch version, without breaking changes
+   npm version minor # if you want to bump the minor version, with breaking changes
+   npm version prerelease --preid=rc # if you want to create a release candidate
    ```
 2. Push the tag to GitHub and trigger the publish workflow that will publish it on NPM with:
 
-   ```
-   git push [remote] vX.Y.Z
+   ```shell
+   git push [remote] <tag>
    ```
 
 3. Unless you are on `master`, create a new branch and push it to GitHub so that the tagged commit belongs to a branch of this repo with:
-   ```
-   git checkout -b X.Y.Z
+   ```shell
+   git checkout -b <tag>
    git push
    ```
    Otherwise, just push to `master`.
@@ -67,20 +69,20 @@ To release a new version:
 
 Compile the TypeScript files into JavaScript:
 
-```
+```shell
 npm run compile
 ```
 
 ## Testing
 
-```
+```shell
 npm run devnet:start // this will start a devnet for smart contract tests
 npm test
 ```
 
 or, to watch for changes:
 
-```
+```shell
 npm run test:watch
 ```
 


### PR DESCRIPTION
Based on today's discoveries, this PR updates the NPM release workflow.

I am also adding the flat `--access public`, because I found in the docs that:

> If you don't have a paid account, you must publish with `--access public` to publish scoped packages.

<details><summary>Today's discoveries...</summary>

So, here’s some news for you: `npm publish --tag 1.1.4-rc0` [fails](https://github.com/alephium/js-sdk/runs/5755698303?check_suite_focus=true) because the tag **SHOULD NOT** be a valid SemVer range:
> Tags that can be interpreted as valid semver ranges will be rejected. For example, v1.4 cannot be used as a tag, because it is interpreted by semver as >=1.4.0 <1.5.0

https://docs.npmjs.com/cli/v8/commands/npm-dist-tag#caveats

Apparently, the purpose of tags is to set aliases instead of version numbers, like `stable`, `latest`, `next`, `rc`, etc...

The correct way of doing things appears to be the following:

- `npm version patch` to bump the patch version (no breaking changes) and publish it with `npm publish --tag latest`
- `npm version minor` to bump the patch version (breaking changes) and publish it with `npm publish --tag latest`
- `npm version prerelease --preid=rc` to create a prerelease and publish it with `npm publish --tag rc` to avoid having latest distribution tag pointing to it.

This helped understand things better: https://stackoverflow.com/questions/47676252/is-npm-install-packagelatest-stable-or-does-it-also-include-alpha-beta-version

</details>