### PR TITLE
Add error utils

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,0 +1,43 @@
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tryGetString = (obj: any): string | null => {
+  return typeof obj.toString === 'function' ? obj.toString() : null
+}
+
+export interface APIError {
+  error: {
+    detail?: string
+    message?: string
+  }
+  status: number
+  statusText: string
+}
+
+const isHTTPError = (e: unknown): e is APIError => {
+  return (e as APIError).error !== undefined
+}
+
+export const getHumanReadableError = (e: unknown, defaultErrorMessage: string) => {
+  const stringifiedError = tryGetString(e)
+  const serverError = isHTTPError(e)
+    ? e.error.detail || `(${e.status}${e.statusText && `: ${e.statusText}`}) ${e.error.message || ''}`
+    : stringifiedError
+  return `${defaultErrorMessage}${serverError && `: ${serverError}`}`
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -24,6 +24,7 @@ export * from './explorer'
 export * from './address'
 export * from './signer'
 export * from './contract'
+export * from './errors'
 export {
   formatAmountForDisplay,
   calAmountDelta,


### PR DESCRIPTION
Our [explorer](https://github.com/alephium/explorer/blob/fix-loading-speed/src/utils/api.ts#L19-L39) and [desktop wallet](https://github.com/alephium/desktop-wallet/blob/master/src/utils/api.ts#L19-L39) (and probably soon the mobile as well) have duplicated code when it comes to error handling. I think this is a good set of code that can be extracted to the SDK.