### PR TITLE
Revert breaking changes

### DIFF
--- a/api/api-alephium.ts
+++ b/api/api-alephium.ts
@@ -10,7 +10,6 @@
  */
 
 export interface AddressBalance {
-  /** @format address */
   address: string
 
   /** @format uint256 */
@@ -28,56 +27,41 @@ export interface AddressBalance {
 }
 
 export interface AddressInfo {
-  /** @format address */
   address: string
-
-  /** @format public-key */
   publicKey: string
-
-  /** @format group-index */
   group: number
   path: string
 }
 
 export interface Addresses {
-  /** @format address */
   activeAddress: string
   addresses: AddressInfo[]
 }
 
 export interface AssetInput {
   outputRef: OutputRef
-
-  /** @format hex-string */
   unlockScript: string
 }
 
 export interface AssetOutput {
-  /** @format int32 */
   hint: number
-
-  /** @format 32-byte-hash */
   key: string
 
   /** @format uint256 */
-  attoAlphAmount: string
-
-  /** @format address */
+  alphAmount: string
   address: string
   tokens: Token[]
 
   /** @format int64 */
   lockTime: number
-
-  /** @format hex-string */
-  message: string
+  additionalData: string
   type: string
 }
 
 export interface AssetState {
   /** @format uint256 */
-  attoAlphAmount: string
-  tokens?: Token[]
+  alphAmount: string
+  tokens: Token[]
 }
 
 export interface BadRequest {
@@ -96,8 +80,6 @@ export interface Balance {
 
   /** @format x.x ALPH */
   lockedBalanceHint: string
-
-  /** @format int32 */
   utxoNum: number
   warning?: string
 }
@@ -123,145 +105,62 @@ export interface Banned {
 }
 
 export interface BlockEntry {
-  /** @format block-hash */
   hash: string
 
   /** @format int64 */
   timestamp: number
-
-  /** @format int32 */
   chainFrom: number
-
-  /** @format int32 */
   chainTo: number
-
-  /** @format int32 */
   height: number
   deps: string[]
   transactions: Transaction[]
-
-  /** @format hex-string */
   nonce: string
   version: number
-
-  /** @format 32-byte-hash */
   depStateHash: string
-
-  /** @format 32-byte-hash */
   txsHash: string
-
-  /** @format hex-string */
   target: string
 }
 
 export interface BlockHeaderEntry {
-  /** @format block-hash */
   hash: string
 
   /** @format int64 */
   timestamp: number
-
-  /** @format int32 */
   chainFrom: number
-
-  /** @format int32 */
   chainTo: number
-
-  /** @format int32 */
   height: number
   deps: string[]
 }
 
 export interface BrokerInfo {
-  /** @format clique-id */
   cliqueId: string
-
-  /** @format int32 */
   brokerId: number
-
-  /** @format int32 */
   brokerNum: number
-
-  /** @format inet-socket-address */
   address: string
 }
 
-export interface BuildDeployContractTx {
-  /** @format public-key */
+export interface BuildContractDeployScriptTx {
   fromPublicKey: string
-
-  /** @format hex-string */
   bytecode: string
+  initialFields: Val[]
 
   /** @format uint256 */
-  initialAttoAlphAmount?: string
-  initialTokenAmounts?: Token[]
+  alphAmount?: string
 
   /** @format uint256 */
   issueTokenAmount?: string
-
-  /** @format gas */
-  gasAmount?: number
+  gas?: number
 
   /** @format uint256 */
   gasPrice?: string
+  utxosLimit?: number
 }
 
-export interface BuildDeployContractTxResult {
-  /** @format int32 */
-  fromGroup: number
-
-  /** @format int32 */
-  toGroup: number
+export interface BuildContractDeployScriptTxResult {
+  group: number
   unsignedTx: string
-
-  /** @format gas */
-  gasAmount: number
-
-  /** @format uint256 */
-  gasPrice: string
-
-  /** @format 32-byte-hash */
   txId: string
-
-  /** @format address */
   contractAddress: string
-}
-
-export interface BuildExecuteScriptTx {
-  /** @format public-key */
-  fromPublicKey: string
-
-  /** @format hex-string */
-  bytecode: string
-
-  /** @format uint256 */
-  attoAlphAmount?: string
-  tokens?: Token[]
-
-  /** @format gas */
-  gasAmount?: number
-
-  /** @format uint256 */
-  gasPrice?: string
-}
-
-export interface BuildExecuteScriptTxResult {
-  /** @format int32 */
-  fromGroup: number
-
-  /** @format int32 */
-  toGroup: number
-  unsignedTx: string
-
-  /** @format gas */
-  gasAmount: number
-
-  /** @format uint256 */
-  gasPrice: string
-
-  /** @format 32-byte-hash */
-  txId: string
 }
 
 export interface BuildInfo {
@@ -270,173 +169,114 @@ export interface BuildInfo {
 }
 
 export interface BuildMultisig {
-  /** @format address */
   fromAddress: string
   fromPublicKeys: string[]
   destinations: Destination[]
-
-  /** @format gas */
   gas?: number
 
   /** @format uint256 */
   gasPrice?: string
+  utxosLimit?: number
 }
 
 export interface BuildMultisigAddress {
   keys: string[]
-
-  /** @format int32 */
   mrequired: number
 }
 
 export interface BuildMultisigAddressResult {
-  /** @format address */
   address: string
 }
 
-export interface BuildSweepAddressTransactions {
-  /** @format public-key */
+export interface BuildScriptTx {
   fromPublicKey: string
+  bytecode: string
 
-  /** @format address */
+  /** @format uint256 */
+  alphAmount?: string
+  tokens?: Token[]
+  gas?: number
+
+  /** @format uint256 */
+  gasPrice?: string
+  utxosLimit?: number
+}
+
+export interface BuildScriptTxResult {
+  unsignedTx: string
+  txId: string
+  group: number
+}
+
+export interface BuildSweepAddressTransactions {
+  fromPublicKey: string
   toAddress: string
 
   /** @format int64 */
   lockTime?: number
-
-  /** @format gas */
-  gasAmount?: number
+  gas?: number
 
   /** @format uint256 */
   gasPrice?: string
+  utxosLimit?: number
 }
 
 export interface BuildSweepAddressTransactionsResult {
   unsignedTxs: SweepAddressTransaction[]
-
-  /** @format int32 */
   fromGroup: number
-
-  /** @format int32 */
   toGroup: number
 }
 
 export interface BuildTransaction {
-  /** @format public-key */
   fromPublicKey: string
   destinations: Destination[]
   utxos?: OutputRef[]
-
-  /** @format gas */
-  gasAmount?: number
+  gas?: number
 
   /** @format uint256 */
   gasPrice?: string
+  utxosLimit?: number
 }
 
 export interface BuildTransactionResult {
   unsignedTx: string
-
-  /** @format gas */
   gasAmount: number
 
   /** @format uint256 */
   gasPrice: string
-
-  /** @format 32-byte-hash */
   txId: string
-
-  /** @format int32 */
   fromGroup: number
-
-  /** @format int32 */
   toGroup: number
 }
 
-export interface CallContract {
-  /** @format int32 */
-  group: number
-
-  /** @format block-hash */
-  worldStateBlockHash?: string
-
-  /** @format 32-byte-hash */
-  txId?: string
-
-  /** @format address */
-  address: string
-
-  /** @format int32 */
-  methodIndex: number
-  args?: Val[]
-  existingContracts?: string[]
-  inputAssets?: TestInputAsset[]
-}
-
-export interface CallContractResult {
-  returns: Val[]
-
-  /** @format int32 */
-  gasUsed: number
-  contracts: ContractState[]
-  txInputs: string[]
-  txOutputs: Output[]
-  events: ContractEventByTxId[]
-}
-
 export interface ChainInfo {
-  /** @format int32 */
   currentHeight: number
 }
 
 export interface ChainParams {
   networkId: number
-
-  /** @format int32 */
   numZerosAtLeastInHash: number
-
-  /** @format int32 */
   groupNumPerBroker: number
-
-  /** @format int32 */
   groups: number
 }
 
 export interface ChangeActiveAddress {
-  /** @format address */
   address: string
 }
 
-export interface CompileContractResult {
+export interface CompileResult {
   bytecode: string
-
-  /** @format 32-byte-hash */
   codeHash: string
   fields: FieldsSig
   functions: FunctionSig[]
   events: EventSig[]
 }
 
-export interface CompileScriptResult {
-  bytecodeTemplate: string
-  fields: FieldsSig
-  functions: FunctionSig[]
-}
-
 export interface Confirmed {
-  /** @format block-hash */
   blockHash: string
-
-  /** @format int32 */
   txIndex: number
-
-  /** @format int32 */
   chainConfirmations: number
-
-  /** @format int32 */
   fromGroupConfirmations: number
-
-  /** @format int32 */
   toGroupConfirmations: number
   type: string
 }
@@ -446,110 +286,62 @@ export interface Contract {
 }
 
 export interface ContractEvent {
-  /** @format block-hash */
   blockHash: string
-
-  /** @format 32-byte-hash */
-  txId: string
-
-  /** @format int32 */
-  eventIndex: number
-  fields: Val[]
-}
-
-export interface ContractEventByTxId {
-  /** @format block-hash */
-  blockHash: string
-
-  /** @format address */
   contractAddress: string
-
-  /** @format int32 */
+  txId: string
   eventIndex: number
   fields: Val[]
-}
-
-export interface ContractEvents {
-  events: ContractEvent[]
-
-  /** @format int32 */
-  nextStart: number
-}
-
-export interface ContractEventsByTxId {
-  events: ContractEventByTxId[]
-
-  /** @format int32 */
-  nextStart: number
+  type: string
 }
 
 export interface ContractOutput {
-  /** @format int32 */
   hint: number
-
-  /** @format 32-byte-hash */
   key: string
 
   /** @format uint256 */
-  attoAlphAmount: string
-
-  /** @format address */
+  alphAmount: string
   address: string
   tokens: Token[]
   type: string
 }
 
 export interface ContractState {
-  /** @format address */
   address: string
-
-  /** @format contract */
   bytecode: string
-
-  /** @format 32-byte-hash */
   codeHash: string
-
-  /** @format 32-byte-hash */
-  initialStateHash?: string
   fields: Val[]
   asset: AssetState
 }
 
-export interface DecodeUnsignedTx {
+export interface DecodeTransaction {
   unsignedTx: string
 }
 
-export interface DecodeUnsignedTxResult {
-  /** @format int32 */
-  fromGroup: number
-
-  /** @format int32 */
-  toGroup: number
-  unsignedTx: UnsignedTx
-}
-
 export interface Destination {
-  /** @format address */
   address: string
 
   /** @format uint256 */
-  attoAlphAmount: string
+  alphAmount: string
   tokens?: Token[]
 
   /** @format int64 */
   lockTime?: number
-
-  /** @format hex-string */
-  message?: string
 }
 
 export type DiscoveryAction = Reachable | Unreachable
 
+export type Event = ContractEvent | TxScriptEvent
+
 export interface EventSig {
   name: string
   signature: string
-  fieldNames: string[]
   fieldTypes: string[]
+}
+
+export interface Events {
+  chainFrom: number
+  chainTo: number
+  events: Event[]
 }
 
 export interface FetchResponse {
@@ -558,41 +350,31 @@ export interface FetchResponse {
 
 export interface FieldsSig {
   signature: string
-  names: string[]
   types: string[]
 }
 
 export interface FixedAssetOutput {
-  /** @format int32 */
   hint: number
-
-  /** @format 32-byte-hash */
   key: string
 
   /** @format uint256 */
-  attoAlphAmount: string
-
-  /** @format address */
+  alphAmount: string
   address: string
   tokens: Token[]
 
   /** @format int64 */
   lockTime: number
-
-  /** @format hex-string */
-  message: string
+  additionalData: string
 }
 
 export interface FunctionSig {
   name: string
   signature: string
-  argNames: string[]
   argTypes: string[]
   returnTypes: string[]
 }
 
 export interface Group {
-  /** @format int32 */
   group: number
 }
 
@@ -600,17 +382,15 @@ export interface HashesAtHeight {
   headers: string[]
 }
 
+export interface InputAsset {
+  address: string
+  asset: AssetState
+}
+
 export interface InterCliquePeerInfo {
-  /** @format clique-id */
   cliqueId: string
-
-  /** @format int32 */
   brokerId: number
-
-  /** @format int32 */
   groupNumPerBroker: number
-
-  /** @format inet-socket-address */
   address: string
   isSynced: boolean
   clientVersion: string
@@ -637,8 +417,6 @@ export type MisbehaviorAction = Ban | Unban
 export interface NodeInfo {
   buildInfo: BuildInfo
   upnp: boolean
-
-  /** @format inet-socket-address */
   externalAddress?: string
 }
 
@@ -654,29 +432,18 @@ export interface NotFound {
 export type Output = AssetOutput | ContractOutput
 
 export interface OutputRef {
-  /** @format int32 */
   hint: number
-
-  /** @format 32-byte-hash */
   key: string
 }
 
 export interface PeerAddress {
-  /** @format inet-address */
   address: string
-
-  /** @format int32 */
   restPort: number
-
-  /** @format int32 */
   wsPort: number
-
-  /** @format int32 */
   minerApiPort: number
 }
 
 export interface PeerMisbehavior {
-  /** @format inet-address */
   peer: string
   status: PeerStatus
 }
@@ -684,7 +451,6 @@ export interface PeerMisbehavior {
 export type PeerStatus = Banned | Penalty
 
 export interface Penalty {
-  /** @format int32 */
   value: number
   type: string
 }
@@ -695,13 +461,8 @@ export interface Reachable {
 }
 
 export interface ReleaseVersion {
-  /** @format int32 */
   major: number
-
-  /** @format int32 */
   minor: number
-
-  /** @format int32 */
   patch: number
 }
 
@@ -718,7 +479,6 @@ export interface Script {
 }
 
 export interface SelfClique {
-  /** @format clique-id */
   cliqueId: string
   nodes: PeerAddress[]
   selfReady: boolean
@@ -734,7 +494,6 @@ export interface Sign {
 }
 
 export interface SignResult {
-  /** @format signature */
   signature: string
 }
 
@@ -745,45 +504,24 @@ export interface SubmitMultisig {
 
 export interface SubmitTransaction {
   unsignedTx: string
-
-  /** @format signature */
   signature: string
 }
 
-export interface SubmitTxResult {
-  /** @format 32-byte-hash */
-  txId: string
-
-  /** @format int32 */
-  fromGroup: number
-
-  /** @format int32 */
-  toGroup: number
-}
-
 export interface Sweep {
-  /** @format address */
   toAddress: string
 
   /** @format int64 */
   lockTime?: number
-
-  /** @format gas */
-  gasAmount?: number
+  gas?: number
 
   /** @format uint256 */
   gasPrice?: string
-
-  /** @format int32 */
   utxosLimit?: number
 }
 
 export interface SweepAddressTransaction {
-  /** @format 32-byte-hash */
   txId: string
   unsignedTx: string
-
-  /** @format gas */
   gasAmount: number
 
   /** @format uint256 */
@@ -791,54 +529,26 @@ export interface SweepAddressTransaction {
 }
 
 export interface TestContract {
-  /** @format int32 */
   group?: number
-
-  /** @format block-hash */
-  blockHash?: string
-
-  /** @format 32-byte-hash */
-  txId?: string
-
-  /** @format address */
   address?: string
-
-  /** @format contract */
   bytecode: string
-  initialFields?: Val[]
+  initialFields: Val[]
   initialAsset?: AssetState
-
-  /** @format int32 */
-  methodIndex?: number
-  args?: Val[]
+  testMethodIndex?: number
+  testArgs: Val[]
   existingContracts?: ContractState[]
-  inputAssets?: TestInputAsset[]
+  inputAssets?: InputAsset[]
 }
 
 export interface TestContractResult {
-  /** @format address */
-  address: string
-
-  /** @format 32-byte-hash */
-  codeHash: string
   returns: Val[]
-
-  /** @format int32 */
   gasUsed: number
   contracts: ContractState[]
-  txInputs: string[]
   txOutputs: Output[]
-  events: ContractEventByTxId[]
-}
-
-export interface TestInputAsset {
-  /** @format address */
-  address: string
-  asset: AssetState
+  events: Event[]
 }
 
 export interface Token {
-  /** @format 32-byte-hash */
   id: string
 
   /** @format uint256 */
@@ -862,25 +572,16 @@ export interface TransactionTemplate {
 
 export interface Transfer {
   destinations: Destination[]
-
-  /** @format gas */
   gas?: number
 
   /** @format uint256 */
   gasPrice?: string
-
-  /** @format int32 */
   utxosLimit?: number
 }
 
 export interface TransferResult {
-  /** @format 32-byte-hash */
   txId: string
-
-  /** @format group-index */
   fromGroup: number
-
-  /** @format group-index */
   toGroup: number
 }
 
@@ -889,6 +590,20 @@ export interface TransferResults {
 }
 
 export interface TxNotFound {
+  type: string
+}
+
+export interface TxResult {
+  txId: string
+  fromGroup: number
+  toGroup: number
+}
+
+export interface TxScriptEvent {
+  blockHash: string
+  txId: string
+  eventIndex: number
+  fields: Val[]
   type: string
 }
 
@@ -903,8 +618,6 @@ export interface UTXO {
 
   /** @format int64 */
   lockTime: number
-
-  /** @format hex-string */
   additionalData: string
 }
 
@@ -923,10 +636,7 @@ export interface Unban {
 }
 
 export interface UnconfirmedTransactions {
-  /** @format int32 */
   fromGroup: number
-
-  /** @format int32 */
   toGroup: number
   unconfirmedTransactions: TransactionTemplate[]
 }
@@ -937,15 +647,10 @@ export interface Unreachable {
 }
 
 export interface UnsignedTx {
-  /** @format 32-byte-hash */
   txId: string
   version: number
   networkId: number
-
-  /** @format script */
   scriptOpt?: string
-
-  /** @format int32 */
   gasAmount: number
 
   /** @format uint256 */
@@ -957,7 +662,6 @@ export interface UnsignedTx {
 export type Val = ValAddress | ValArray | ValBool | ValByteVec | ValI256 | ValU256
 
 export interface ValAddress {
-  /** @format address */
   value: string
   type: string
 }
@@ -973,13 +677,11 @@ export interface ValBool {
 }
 
 export interface ValByteVec {
-  /** @format hex-string */
   value: string
   type: string
 }
 
 export interface ValI256 {
-  /** @format bigint */
   value: string
   type: string
 }
@@ -991,13 +693,8 @@ export interface ValU256 {
 }
 
 export interface VerifySignature {
-  /** @format hex-string */
   data: string
-
-  /** @format signature */
   signature: string
-
-  /** @format public-key */
   publicKey: string
 }
 
@@ -1252,7 +949,7 @@ export class HttpClient<SecurityDataType = unknown> {
 
 /**
  * @title Alephium API
- * @version 1.4.0
+ * @version 1.3.0
  * @baseUrl {protocol}://{host}:{port}
  */
 export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDataType> {
@@ -1388,10 +1085,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @summary Get your total balance
      * @request GET:/wallets/{wallet_name}/balances
      */
-    getWalletsWalletNameBalances: (walletName: string, params: RequestParams = {}) =>
+    getWalletsWalletNameBalances: (walletName: string, query?: { utxosLimit?: number }, params: RequestParams = {}) =>
       this.request<Balances, BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>({
         path: `/wallets/${walletName}/balances`,
         method: 'GET',
+        query: query,
         format: 'json',
         ...params
       }),
@@ -1908,10 +1606,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @summary Get the balance of an address
      * @request GET:/addresses/{address}/balance
      */
-    getAddressesAddressBalance: (address: string, params: RequestParams = {}) =>
+    getAddressesAddressBalance: (address: string, query?: { utxosLimit?: number }, params: RequestParams = {}) =>
       this.request<Balance, BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>({
         path: `/addresses/${address}/balance`,
         method: 'GET',
+        query: query,
         format: 'json',
         ...params
       }),
@@ -1924,10 +1623,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @summary Get the UTXOs of an address
      * @request GET:/addresses/{address}/utxos
      */
-    getAddressesAddressUtxos: (address: string, params: RequestParams = {}) =>
+    getAddressesAddressUtxos: (address: string, query?: { utxosLimit?: number }, params: RequestParams = {}) =>
       this.request<UTXOs, BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>({
         path: `/addresses/${address}/utxos`,
         method: 'GET',
+        query: query,
         format: 'json',
         ...params
       }),
@@ -2019,7 +1719,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request POST:/transactions/submit
      */
     postTransactionsSubmit: (data: SubmitTransaction, params: RequestParams = {}) =>
-      this.request<SubmitTxResult, BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>({
+      this.request<TxResult, BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>({
         path: `/transactions/submit`,
         method: 'POST',
         body: data,
@@ -2036,11 +1736,8 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @summary Decode an unsigned transaction
      * @request POST:/transactions/decode-unsigned-tx
      */
-    postTransactionsDecodeUnsignedTx: (data: DecodeUnsignedTx, params: RequestParams = {}) =>
-      this.request<
-        DecodeUnsignedTxResult,
-        BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable
-      >({
+    postTransactionsDecodeUnsignedTx: (data: DecodeTransaction, params: RequestParams = {}) =>
+      this.request<UnsignedTx, BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>({
         path: `/transactions/decode-unsigned-tx`,
         method: 'POST',
         body: data,
@@ -2079,10 +1776,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request POST:/contracts/compile-script
      */
     postContractsCompileScript: (data: Script, params: RequestParams = {}) =>
-      this.request<
-        CompileScriptResult,
-        BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable
-      >({
+      this.request<CompileResult, BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>({
         path: `/contracts/compile-script`,
         method: 'POST',
         body: data,
@@ -2095,16 +1789,16 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * No description
      *
      * @tags Contracts
-     * @name PostContractsUnsignedTxExecuteScript
+     * @name PostContractsUnsignedTxBuildScript
      * @summary Build an unsigned script
-     * @request POST:/contracts/unsigned-tx/execute-script
+     * @request POST:/contracts/unsigned-tx/build-script
      */
-    postContractsUnsignedTxExecuteScript: (data: BuildExecuteScriptTx, params: RequestParams = {}) =>
+    postContractsUnsignedTxBuildScript: (data: BuildScriptTx, params: RequestParams = {}) =>
       this.request<
-        BuildExecuteScriptTxResult,
+        BuildScriptTxResult,
         BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable
       >({
-        path: `/contracts/unsigned-tx/execute-script`,
+        path: `/contracts/unsigned-tx/build-script`,
         method: 'POST',
         body: data,
         type: ContentType.Json,
@@ -2121,10 +1815,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request POST:/contracts/compile-contract
      */
     postContractsCompileContract: (data: Contract, params: RequestParams = {}) =>
-      this.request<
-        CompileContractResult,
-        BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable
-      >({
+      this.request<CompileResult, BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>({
         path: `/contracts/compile-contract`,
         method: 'POST',
         body: data,
@@ -2137,16 +1828,16 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * No description
      *
      * @tags Contracts
-     * @name PostContractsUnsignedTxDeployContract
+     * @name PostContractsUnsignedTxBuildContract
      * @summary Build an unsigned contract
-     * @request POST:/contracts/unsigned-tx/deploy-contract
+     * @request POST:/contracts/unsigned-tx/build-contract
      */
-    postContractsUnsignedTxDeployContract: (data: BuildDeployContractTx, params: RequestParams = {}) =>
+    postContractsUnsignedTxBuildContract: (data: BuildContractDeployScriptTx, params: RequestParams = {}) =>
       this.request<
-        BuildDeployContractTxResult,
+        BuildContractDeployScriptTxResult,
         BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable
       >({
-        path: `/contracts/unsigned-tx/deploy-contract`,
+        path: `/contracts/unsigned-tx/build-contract`,
         method: 'POST',
         body: data,
         type: ContentType.Json,
@@ -2183,26 +1874,6 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       this.request<TestContractResult, BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>(
         {
           path: `/contracts/test-contract`,
-          method: 'POST',
-          body: data,
-          type: ContentType.Json,
-          format: 'json',
-          ...params
-        }
-      ),
-
-    /**
-     * No description
-     *
-     * @tags Contracts
-     * @name PostContractsCallContract
-     * @summary Call contract
-     * @request POST:/contracts/call-contract
-     */
-    postContractsCallContract: (data: CallContract, params: RequestParams = {}) =>
-      this.request<CallContractResult, BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>(
-        {
-          path: `/contracts/call-contract`,
           method: 'POST',
           body: data,
           type: ContentType.Json,
@@ -2263,7 +1934,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request POST:/multisig/submit
      */
     postMultisigSubmit: (data: SubmitMultisig, params: RequestParams = {}) =>
-      this.request<SubmitTxResult, BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>({
+      this.request<TxResult, BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>({
         path: `/multisig/submit`,
         method: 'POST',
         body: data,
@@ -2362,17 +2033,13 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * No description
      *
      * @tags Events
-     * @name GetEventsContractContractaddress
-     * @summary Get events for a contract within a counter range
-     * @request GET:/events/contract/{contractAddress}
+     * @name GetEventsContractInBlock
+     * @summary Get events for a contract within a block
+     * @request GET:/events/contract/in-block
      */
-    getEventsContractContractaddress: (
-      contractAddress: string,
-      query: { start: number; end?: number; group?: number },
-      params: RequestParams = {}
-    ) =>
-      this.request<ContractEvents, BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>({
-        path: `/events/contract/${contractAddress}`,
+    getEventsContractInBlock: (query: { block: string; contractAddress: string }, params: RequestParams = {}) =>
+      this.request<Events, BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>({
+        path: `/events/contract/in-block`,
         method: 'GET',
         query: query,
         format: 'json',
@@ -2383,14 +2050,18 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * No description
      *
      * @tags Events
-     * @name GetEventsContractContractaddressCurrentCount
-     * @summary Get current value of the events counter for a contract
-     * @request GET:/events/contract/{contractAddress}/current-count
+     * @name GetEventsContractWithinBlocks
+     * @summary Get events for a contract within a range of blocks
+     * @request GET:/events/contract/within-blocks
      */
-    getEventsContractContractaddressCurrentCount: (contractAddress: string, params: RequestParams = {}) =>
-      this.request<number, BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>({
-        path: `/events/contract/${contractAddress}/current-count`,
+    getEventsContractWithinBlocks: (
+      query: { fromBlock: string; toBlock?: string; contractAddress: string },
+      params: RequestParams = {}
+    ) =>
+      this.request<Events[], BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>({
+        path: `/events/contract/within-blocks`,
         method: 'GET',
+        query: query,
         format: 'json',
         ...params
       }),
@@ -2399,16 +2070,33 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * No description
      *
      * @tags Events
-     * @name GetEventsTxIdTxid
-     * @summary Get events for a TxScript
-     * @request GET:/events/tx-id/{txId}
+     * @name GetEventsContractWithinTimeInterval
+     * @summary Get events for a contract within a time interval
+     * @request GET:/events/contract/within-time-interval
      */
-    getEventsTxIdTxid: (txId: string, query?: { group?: number }, params: RequestParams = {}) =>
-      this.request<
-        ContractEventsByTxId,
-        BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable
-      >({
-        path: `/events/tx-id/${txId}`,
+    getEventsContractWithinTimeInterval: (
+      query: { fromTs: number; toTs?: number; contractAddress: string },
+      params: RequestParams = {}
+    ) =>
+      this.request<Events[], BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>({
+        path: `/events/contract/within-time-interval`,
+        method: 'GET',
+        query: query,
+        format: 'json',
+        ...params
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Events
+     * @name GetEventsTxScript
+     * @summary Get events for a TxScript
+     * @request GET:/events/tx-script
+     */
+    getEventsTxScript: (query: { block: string; txId: string }, params: RequestParams = {}) =>
+      this.request<Events, BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>({
+        path: `/events/tx-script`,
         method: 'GET',
         query: query,
         format: 'json',

--- a/api/api-explorer.ts
+++ b/api/api-explorer.ts
@@ -23,8 +23,6 @@ export interface AddressInfo {
 
   /** @format uint256 */
   lockedBalance: string
-
-  /** @format int32 */
   txNumber: number
 }
 
@@ -33,22 +31,13 @@ export interface BadRequest {
 }
 
 export interface BlockEntryLite {
-  /** @format block-hash */
   hash: string
 
   /** @format int64 */
   timestamp: number
-
-  /** @format int32 */
   chainFrom: number
-
-  /** @format int32 */
   chainTo: number
-
-  /** @format int32 */
   height: number
-
-  /** @format int32 */
   txNumber: number
   mainChain: boolean
 
@@ -57,18 +46,13 @@ export interface BlockEntryLite {
 }
 
 export interface ConfirmedTransaction {
-  /** @format 32-byte-hash */
   hash: string
-
-  /** @format block-hash */
   blockHash: string
 
   /** @format int64 */
   timestamp: number
   inputs?: Input[]
   outputs?: Output[]
-
-  /** @format int32 */
   gasAmount: number
 
   /** @format uint256 */
@@ -84,15 +68,13 @@ export interface ExplorerInfo {
 export interface Hashrate {
   /** @format int64 */
   timestamp: number
-  hashrate: number
-  value: number
+  hashrate: string
+  value: string
 }
 
 export interface Input {
   outputRef: OutputRef
   unlockScript?: string
-
-  /** @format 32-byte-hash */
   txHashRef: string
   address: string
 
@@ -105,7 +87,6 @@ export interface InternalServerError {
 }
 
 export interface ListBlocks {
-  /** @format int32 */
   total: number
   blocks?: BlockEntryLite[]
 }
@@ -116,10 +97,7 @@ export interface NotFound {
 }
 
 export interface Output {
-  /** @format int32 */
   hint: number
-
-  /** @format 32-byte-hash */
   key: string
 
   /** @format uint256 */
@@ -128,24 +106,16 @@ export interface Output {
 
   /** @format int64 */
   lockTime?: number
-
-  /** @format 32-byte-hash */
   spent?: string
 }
 
 export interface OutputRef {
-  /** @format int32 */
   hint: number
-
-  /** @format 32-byte-hash */
   key: string
 }
 
 export interface PerChainCount {
-  /** @format int32 */
   chainFrom: number
-
-  /** @format int32 */
   chainTo: number
 
   /** @format int64 */
@@ -153,10 +123,7 @@ export interface PerChainCount {
 }
 
 export interface PerChainDuration {
-  /** @format int32 */
   chainFrom: number
-
-  /** @format int32 */
   chainTo: number
 
   /** @format int64 */
@@ -167,10 +134,7 @@ export interface PerChainDuration {
 }
 
 export interface PerChainHeight {
-  /** @format int32 */
   chainFrom: number
-
-  /** @format int32 */
   chainTo: number
 
   /** @format int64 */
@@ -219,18 +183,13 @@ export interface TokenSupply {
 }
 
 export interface Transaction {
-  /** @format 32-byte-hash */
   hash: string
-
-  /** @format block-hash */
   blockHash: string
 
   /** @format int64 */
   timestamp: number
   inputs?: Input[]
   outputs?: Output[]
-
-  /** @format int32 */
   gasAmount: number
 
   /** @format uint256 */
@@ -258,18 +217,11 @@ export interface Unauthorized {
 }
 
 export interface UnconfirmedTransaction {
-  /** @format 32-byte-hash */
   hash: string
-
-  /** @format int32 */
   chainFrom: number
-
-  /** @format int32 */
   chainTo: number
   inputs?: UInput[]
   outputs?: UOutput[]
-
-  /** @format int32 */
   gasAmount: number
 
   /** @format uint256 */
@@ -681,7 +633,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request GET:/infos/supply/total-alph
      */
     getInfosSupplyTotalAlph: (params: RequestParams = {}) =>
-      this.request<number, BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>({
+      this.request<string, BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>({
         path: `/infos/supply/total-alph`,
         method: 'GET',
         ...params
@@ -695,7 +647,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request GET:/infos/supply/circulating-alph
      */
     getInfosSupplyCirculatingAlph: (params: RequestParams = {}) =>
-      this.request<number, BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>({
+      this.request<string, BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>({
         path: `/infos/supply/circulating-alph`,
         method: 'GET',
         ...params
@@ -709,7 +661,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request GET:/infos/supply/reserved-alph
      */
     getInfosSupplyReservedAlph: (params: RequestParams = {}) =>
-      this.request<number, BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>({
+      this.request<string, BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>({
         path: `/infos/supply/reserved-alph`,
         method: 'GET',
         ...params
@@ -723,7 +675,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request GET:/infos/supply/locked-alph
      */
     getInfosSupplyLockedAlph: (params: RequestParams = {}) =>
-      this.request<number, BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>({
+      this.request<string, BadRequest | Unauthorized | NotFound | InternalServerError | ServiceUnavailable>({
         path: `/infos/supply/locked-alph`,
         method: 'GET',
         ...params

--- a/lib/contract.ts
+++ b/lib/contract.ts
@@ -1,0 +1,882 @@
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import * as cryptojs from 'crypto-js'
+import * as crypto from 'crypto'
+import bs58 from './bs58'
+import fs from 'fs'
+import { promises as fsPromises } from 'fs'
+import { CliqueClient } from './clique'
+import * as api from '../api/api-alephium'
+import { Signer } from './signer'
+
+type ContractVariables = Record<string, string>
+
+export abstract class Common {
+  readonly fileName: string
+  readonly sourceCodeSha256: string
+  readonly bytecode: string
+  readonly codeHash: string
+  readonly functions: api.FunctionSig[]
+
+  static readonly importRegex = new RegExp('^import "[a-z][a-z_0-9]*.ral"', 'mg')
+  static readonly contractRegex = new RegExp('^TxContract [A-Z][a-zA-Z0-9]*\\(', 'mg')
+  static readonly scriptRegex = new RegExp('^TxScript [A-Z][a-zA-Z0-9]* \\{', 'mg')
+  static readonly variableRegex = new RegExp('\\{\\{\\s+[a-z][a-zA-Z0-9]*\\s+\\}\\}', 'g')
+
+  constructor(
+    fileName: string,
+    sourceCodeSha256: string,
+    bytecode: string,
+    codeHash: string,
+    functions: api.FunctionSig[]
+  ) {
+    this.fileName = fileName
+    this.sourceCodeSha256 = sourceCodeSha256
+    this.bytecode = bytecode
+    this.codeHash = codeHash
+    this.functions = functions
+  }
+
+  protected static _contractPath(fileName: string): string {
+    return `./contracts/${fileName}`
+  }
+
+  protected static _artifactPath(fileName: string): string {
+    return `./artifacts/${fileName}.json`
+  }
+
+  protected static _artifactsFolder(): string {
+    return './artifacts/'
+  }
+
+  static async handleImports(contractStr: string, importsCache: string[]): Promise<string> {
+    const localImportsCache: string[] = []
+    let result = contractStr.replace(Common.importRegex, (match) => {
+      localImportsCache.push(match)
+      return ''
+    })
+    for (const myImport of localImportsCache) {
+      const fileName = myImport.slice(8, -1)
+      if (!importsCache.includes(fileName)) {
+        importsCache.push(fileName)
+        const importContractStr = await Common._loadContractStr(fileName, importsCache, (code) =>
+          Contract.checkCodeType(fileName, code)
+        )
+        result = result.concat('\n', importContractStr)
+      }
+    }
+    return result
+  }
+
+  protected static _replaceVariables(contractStr: string, variables?: ContractVariables): string {
+    if (variables) {
+      return contractStr.replace(Common.variableRegex, (match) => {
+        const variableName = match.split(/(\s+)/)[2]
+        if (variableName in variables) {
+          return variables[variableName].toString()
+        } else {
+          throw new Error(`The value of variable ${variableName} is not provided`)
+        }
+      })
+    } else {
+      return contractStr
+    }
+  }
+
+  protected static async _loadContractStr(
+    fileName: string,
+    importsCache: string[],
+    validate: (fileName: string) => void
+  ): Promise<string> {
+    const contractPath = this._contractPath(fileName)
+    const contractBuffer = await fsPromises.readFile(contractPath)
+    const contractStr = contractBuffer.toString()
+
+    validate(contractStr)
+    return Common.handleImports(contractStr, importsCache)
+  }
+
+  static checkFileNameExtension(fileName: string): void {
+    if (!fileName.endsWith('.ral')) {
+      throw new Error('Smart contract file name should end with ".ral"')
+    }
+  }
+
+  protected static async _from<T extends { sourceCodeSha256: string }>(
+    client: CliqueClient,
+    fileName: string,
+    loadContractStr: (fileName: string, importsCache: string[]) => Promise<string>,
+    loadContract: (fileName: string) => Promise<T>,
+    __from: (client: CliqueClient, fileName: string, contractStr: string, contractHash: string) => Promise<T>
+  ): Promise<T> {
+    Common.checkFileNameExtension(fileName)
+
+    const contractStr = await loadContractStr(fileName, [])
+    const contractHash = cryptojs.SHA256(contractStr).toString()
+    try {
+      const existingContract = await loadContract(fileName)
+      return existingContract.sourceCodeSha256 === contractHash
+        ? existingContract
+        : __from(client, fileName, contractStr, contractHash)
+    } catch (_) {
+      return __from(client, fileName, contractStr, contractHash)
+    }
+  }
+
+  static async load(fileName: string): Promise<Contract | Script> {
+    return Contract.loadContract(fileName).catch(() => Script.loadContract(fileName))
+  }
+
+  protected _saveToFile(): Promise<void> {
+    const artifactPath = Common._artifactPath(this.fileName)
+    return fsPromises.writeFile(artifactPath, this.toString())
+  }
+}
+
+export class Contract extends Common {
+  readonly fields: api.FieldsSig
+  readonly events: api.EventSig[]
+
+  // cache address for contracts
+  private _contractAddresses: Map<string, string>
+
+  constructor(
+    fileName: string,
+    sourceCodeSha256: string,
+    bytecode: string,
+    codeHash: string,
+    fields: api.FieldsSig,
+    functions: api.FunctionSig[],
+    events: api.EventSig[]
+  ) {
+    super(fileName, sourceCodeSha256, bytecode, codeHash, functions)
+    this.fields = fields
+    this.events = events
+
+    this._contractAddresses = new Map<string, string>()
+  }
+
+  static checkCodeType(fileName: string, contractStr: string): void {
+    const contractMatches = contractStr.match(Contract.contractRegex)
+    if (contractMatches === null) {
+      throw new Error(`No contract found in: ${fileName}`)
+    } else if (contractMatches?.length > 1) {
+      throw new Error(`Multiple contracts in: ${fileName}`)
+    } else {
+      return
+    }
+  }
+
+  static async loadContractStr(
+    fileName: string,
+    importsCache: string[],
+    variables?: ContractVariables
+  ): Promise<string> {
+    const result = await Common._loadContractStr(fileName, importsCache, (code) =>
+      Contract.checkCodeType(fileName, code)
+    )
+    return Common._replaceVariables(result, variables)
+  }
+
+  static async from(client: CliqueClient, fileName: string, variables?: ContractVariables): Promise<Contract> {
+    if (!fs.existsSync(Common._artifactsFolder())) {
+      fs.mkdirSync(Common._artifactsFolder(), { recursive: true })
+    }
+    return Common._from(
+      client,
+      fileName,
+      (fileName, importCaches) => Contract.loadContractStr(fileName, importCaches, variables),
+      Contract.loadContract,
+      Contract.__from
+    )
+  }
+
+  private static async __from(
+    client: CliqueClient,
+    fileName: string,
+    contractStr: string,
+    contractHash: string
+  ): Promise<Contract> {
+    const compiled = (await client.contracts.postContractsCompileContract({ code: contractStr })).data
+    const artifact = new Contract(
+      fileName,
+      contractHash,
+      compiled.bytecode,
+      compiled.codeHash,
+      compiled.fields,
+      compiled.functions,
+      compiled.events
+    )
+    await artifact._saveToFile()
+    return artifact
+  }
+
+  static async loadContract(fileName: string): Promise<Contract> {
+    const artifactPath = Contract._artifactPath(fileName)
+    const content = await fsPromises.readFile(artifactPath)
+    const artifact = JSON.parse(content.toString())
+    if (artifact.bytecode == null || artifact.fields == null || artifact.functions == null || artifact.events == null) {
+      throw new Event('Compilation did not return the right data')
+    }
+    return new Contract(
+      fileName,
+      artifact.sourceCodeSha256,
+      artifact.bytecode,
+      artifact.codeHash,
+      artifact.fields,
+      artifact.functions,
+      artifact.events
+    )
+  }
+
+  toString(): string {
+    return JSON.stringify(
+      {
+        sourceCodeSha256: this.sourceCodeSha256,
+        bytecode: this.bytecode,
+        codeHash: this.codeHash,
+        fields: this.fields,
+        functions: this.functions,
+        events: this.events
+      },
+      null,
+      2
+    )
+  }
+
+  toState(fields: Val[], asset: Asset, address: string): ContractState {
+    return {
+      fileName: this.fileName,
+      address: address,
+      bytecode: this.bytecode,
+      codeHash: this.codeHash,
+      fields: fields,
+      fieldTypes: this.fields.types,
+      asset: asset
+    }
+  }
+
+  static randomAddress(): string {
+    const bytes = crypto.randomBytes(33)
+    bytes[0] = 3
+    return bs58.encode(bytes)
+  }
+
+  private _randomAddressWithCache(fileName: string): string {
+    const address = Contract.randomAddress()
+    this._contractAddresses.set(address, fileName)
+    return address
+  }
+
+  async test(client: CliqueClient, funcName: string, params: TestContractParams): Promise<TestContractResult> {
+    this._contractAddresses.clear()
+    const apiParams: api.TestContract = this.toTestContract(funcName, params)
+    const response = await client.contracts.postContractsTestContract(apiParams)
+    const methodIndex = params.testMethodIndex ? params.testMethodIndex : this.getMethodIndex(funcName)
+    const result = await this.fromTestContractResult(methodIndex, response.data)
+    this._contractAddresses.clear()
+    return result
+  }
+
+  toApiFields(fields?: Val[]): api.Val[] {
+    return fields ? toApiFields(fields, this.fields.types) : []
+  }
+
+  toApiArgs(funcName: string, args?: Val[]): api.Val[] {
+    if (args) {
+      const func = this.functions.find((func) => func.name == funcName)
+      if (func == null) {
+        throw new Error(`Invalid function name: ${funcName}`)
+      }
+
+      if (args.length === func.argTypes.length) {
+        return args.map((arg, index) => toApiVal(arg, func.argTypes[index]))
+      } else {
+        throw new Error(`Invalid number of arguments: ${args}`)
+      }
+    } else {
+      return []
+    }
+  }
+
+  getMethodIndex(funcName: string): number {
+    return this.functions.findIndex((func) => func.name === funcName)
+  }
+
+  toApiContractState(state: ContractState): api.ContractState {
+    if (state.address) {
+      this._contractAddresses.set(state.address, state.fileName)
+      return toApiContractState(state, state.address)
+    } else {
+      const address = this._randomAddressWithCache(state.fileName)
+      return toApiContractState(state, address)
+    }
+  }
+
+  toApiContractStates(states?: ContractState[]): api.ContractState[] | undefined {
+    return states ? states.map((state) => this.toApiContractState(state)) : undefined
+  }
+
+  toTestContract(funcName: string, params: TestContractParams): api.TestContract {
+    const address: string = params.address
+      ? (this._contractAddresses.set(params.address, this.fileName), params.address)
+      : this._randomAddressWithCache(this.fileName)
+    return {
+      group: params.group,
+      address: address,
+      bytecode: this.bytecode,
+      initialFields: this.toApiFields(params.initialFields),
+      initialAsset: params.initialAsset ? toApiAsset(params.initialAsset) : undefined,
+      testMethodIndex: this.getMethodIndex(funcName),
+      testArgs: this.toApiArgs(funcName, params.testArgs),
+      existingContracts: this.toApiContractStates(params.existingContracts),
+      inputAssets: toApiInputAssets(params.inputAssets)
+    }
+  }
+
+  static async getContract(codeHash: string): Promise<Contract> {
+    const files = await fsPromises.readdir(Common._artifactsFolder())
+    for (const file of files) {
+      if (file.endsWith('.ral.json')) {
+        const fileName = file.slice(0, -5)
+        const contract = await Common.load(fileName)
+        if (contract.codeHash === codeHash) {
+          return contract as Contract
+        }
+      }
+    }
+
+    throw new Error(`Unknown code with codeHash: ${codeHash}`)
+  }
+
+  static async getFieldTypes(codeHash: string): Promise<string[]> {
+    return Contract.getContract(codeHash).then((contract) => contract.fields.types)
+  }
+
+  async fromApiContractState(state: api.ContractState): Promise<ContractState> {
+    const contract = await Contract.getContract(state.codeHash)
+    return {
+      fileName: contract.fileName,
+      address: state.address,
+      bytecode: state.bytecode,
+      codeHash: state.codeHash,
+      fields: fromApiVals(state.fields, contract.fields.types),
+      fieldTypes: await Contract.getFieldTypes(state.codeHash),
+      asset: fromApiAsset(state.asset)
+    }
+  }
+
+  static async fromApiEvent(event: api.Event, fileName: string): Promise<ContractEvent> {
+    let fieldTypes: string[]
+    let name: string
+
+    if (event.eventIndex == -1) {
+      name = 'ContractCreated'
+      fieldTypes = ['Address']
+    } else if (event.eventIndex == -2) {
+      name = 'ContractDestroyed'
+      fieldTypes = ['Address']
+    } else {
+      const contract = await Contract.loadContract(fileName)
+      const eventDef = await contract.events[event.eventIndex]
+      name = eventDef.name
+      fieldTypes = eventDef.fieldTypes
+    }
+
+    if (event.type === 'ContractEvent') {
+      return {
+        blockHash: event.blockHash,
+        contractAddress: (event as api.ContractEvent).contractAddress,
+        txId: event.txId,
+        name: name,
+        fields: fromApiVals(event.fields, fieldTypes)
+      }
+    } else {
+      throw new Error(`Expected ContractEvent only, but got ${event.type}`)
+    }
+  }
+
+  async fromTestContractResult(methodIndex: number, result: api.TestContractResult): Promise<TestContractResult> {
+    return {
+      returns: fromApiVals(result.returns, this.functions[methodIndex].returnTypes),
+      gasUsed: result.gasUsed,
+      contracts: await Promise.all(result.contracts.map((contract) => this.fromApiContractState(contract))),
+      txOutputs: result.txOutputs.map(fromApiOutput),
+      events: await Promise.all(
+        result.events.map((event) => {
+          const contractAddressKey = (event as api.ContractEvent).contractAddress
+          const contractAddress = this._contractAddresses.get(contractAddressKey)
+          if (contractAddress === undefined) throw new Error("Contract address couldn't be found")
+          return Contract.fromApiEvent(event, contractAddress)
+        })
+      )
+    }
+  }
+
+  async transactionForDeployment(
+    signer: Signer,
+    initialFields?: Val[],
+    issueTokenAmount?: string
+  ): Promise<DeployContractTransaction> {
+    const params: api.BuildContractDeployScriptTx = {
+      fromPublicKey: await signer.getPublicKey(),
+      bytecode: this.bytecode,
+      initialFields: this.toApiFields(initialFields),
+      issueTokenAmount: issueTokenAmount
+    }
+    const response = await signer.client.contracts.postContractsUnsignedTxBuildContract(params)
+    return fromApiDeployContractUnsignedTx(CliqueClient.convert(response))
+  }
+}
+
+export class Script extends Common {
+  constructor(
+    fileName: string,
+    sourceCodeSha256: string,
+    bytecode: string,
+    codeHash: string,
+    functions: api.FunctionSig[]
+  ) {
+    super(fileName, sourceCodeSha256, bytecode, codeHash, functions)
+  }
+
+  static checkCodeType(fileName: string, contractStr: string): void {
+    const scriptMatches = contractStr.match(this.scriptRegex)
+    if (scriptMatches === null) {
+      throw new Error(`No script found in: ${fileName}`)
+    } else if (scriptMatches.length > 1) {
+      throw new Error(`Multiple scripts in: ${fileName}`)
+    } else {
+      return
+    }
+  }
+
+  static async loadContractStr(
+    fileName: string,
+    importsCache: string[],
+    variables?: ContractVariables
+  ): Promise<string> {
+    const result = await Common._loadContractStr(fileName, importsCache, (code) => Script.checkCodeType(fileName, code))
+    return await Common._replaceVariables(result, variables)
+  }
+
+  static async from(client: CliqueClient, fileName: string, variables?: ContractVariables): Promise<Script> {
+    return Common._from(
+      client,
+      fileName,
+      (fileName, importsCache) => Script.loadContractStr(fileName, importsCache, variables),
+      Script.loadContract,
+      Script.__from
+    )
+  }
+
+  private static async __from(
+    client: CliqueClient,
+    fileName: string,
+    scriptStr: string,
+    contractHash: string
+  ): Promise<Script> {
+    const compiled = (await client.contracts.postContractsCompileScript({ code: scriptStr })).data
+    const artifact = new Script(fileName, contractHash, compiled.bytecode, compiled.codeHash, compiled.functions)
+    await artifact._saveToFile()
+    return artifact
+  }
+
+  static async loadContract(fileName: string): Promise<Script> {
+    const artifactPath = Common._artifactPath(fileName)
+    const content = await fsPromises.readFile(artifactPath)
+    const artifact = JSON.parse(content.toString())
+    if (artifact.bytecode == null || artifact.functions == null) {
+      throw new Event('= Compilation did not return the right data')
+    }
+    return new Script(fileName, artifact.sourceCodeSha256, artifact.bytecode, artifact.codeHash, artifact.functions)
+  }
+
+  toString(): string {
+    return JSON.stringify(
+      {
+        sourceCodeSha256: this.sourceCodeSha256,
+        bytecode: this.bytecode,
+        codeHash: this.codeHash,
+        functions: this.functions
+      },
+      null,
+      2
+    )
+  }
+
+  async transactionForDeployment(signer: Signer, params?: BuildScriptTx): Promise<BuildScriptTxResult> {
+    const apiParams: api.BuildScriptTx = {
+      fromPublicKey: await signer.getPublicKey(),
+      bytecode: this.bytecode,
+      alphAmount: params && params.alphAmount ? extractNumber256(params.alphAmount) : undefined,
+      tokens: params && params.tokens ? params.tokens.map(toApiToken) : undefined,
+      gas: params && params.gas ? params.gas : undefined,
+      gasPrice: params && params.gasPrice ? extractNumber256(params.gasPrice) : undefined,
+      utxosLimit: params && params.utxosLimit ? params.utxosLimit : undefined
+    }
+    const response = await signer.client.contracts.postContractsUnsignedTxBuildScript(apiParams)
+    return CliqueClient.convert(response)
+  }
+}
+
+export type Number256 = number | bigint
+export type Val = Number256 | boolean | string | Val[]
+
+function extractBoolean(v: Val): boolean {
+  if (typeof v === 'boolean') {
+    return v
+  } else {
+    throw new Error(`Invalid boolean value: ${v}`)
+  }
+}
+
+// TODO: check integer bounds
+function extractNumber256(v: Val): string {
+  if ((typeof v === 'number' && Number.isInteger(v)) || typeof v === 'bigint') {
+    return v.toString()
+  } else if (typeof v === 'string') {
+    return v
+  } else {
+    throw new Error(`Invalid 256 bit number: ${v}`)
+  }
+}
+
+// TODO: check hex string
+function extractByteVec(v: Val): string {
+  if (typeof v === 'string') {
+    // try to convert from address to contract id
+    try {
+      const address = bs58.decode(v)
+      if (address.length == 33 && address[0] == 3) {
+        return Buffer.from(address.slice(1)).toString('hex')
+      }
+    } catch (_) {
+      return v as string
+    }
+    return v as string
+  } else {
+    throw new Error(`Invalid string: ${v}`)
+  }
+}
+
+function extractBs58(v: Val): string {
+  if (typeof v === 'string') {
+    try {
+      bs58.decode(v)
+      return v as string
+    } catch (error) {
+      throw new Error(`Invalid base58 string: ${v}`)
+    }
+  } else {
+    throw new Error(`Invalid string: ${v}`)
+  }
+}
+
+function decodeNumber256(n: string): Number256 {
+  if (Number.isSafeInteger(Number.parseInt(n))) {
+    return Number(n)
+  } else {
+    return BigInt(n)
+  }
+}
+
+export function extractArray(tpe: string, v: Val): api.Val {
+  if (!Array.isArray(v)) {
+    throw new Error(`Expected array, got ${v}`)
+  }
+
+  const semiColonIndex = tpe.lastIndexOf(';')
+  if (semiColonIndex == -1) {
+    throw new Error(`Invalid Val type: ${tpe}`)
+  }
+
+  const subType = tpe.slice(1, semiColonIndex)
+  const dim = parseInt(tpe.slice(semiColonIndex + 1, -1))
+  if ((v as Val[]).length != dim) {
+    throw new Error(`Invalid val dimension: ${v}`)
+  } else {
+    return { value: (v as Val[]).map((v) => toApiVal(v, subType)), type: 'Array' }
+  }
+}
+
+function toApiVal(v: Val, tpe: string): api.Val {
+  if (tpe === 'Bool') {
+    return { value: extractBoolean(v), type: tpe }
+  } else if (tpe === 'U256' || tpe === 'I256') {
+    return { value: extractNumber256(v), type: tpe }
+  } else if (tpe === 'ByteVec') {
+    return { value: extractByteVec(v), type: tpe }
+  } else if (tpe === 'Address') {
+    return { value: extractBs58(v), type: tpe }
+  } else {
+    return extractArray(tpe, v)
+  }
+}
+
+function decodeArrayType(tpe: string): [baseType: string, dims: number[]] {
+  const semiColonIndex = tpe.lastIndexOf(';')
+  if (semiColonIndex === -1) {
+    throw new Error(`Invalid Val type: ${tpe}`)
+  }
+
+  const subType = tpe.slice(1, semiColonIndex)
+  const dim = parseInt(tpe.slice(semiColonIndex + 1, -1))
+  if (subType[0] == '[') {
+    const [baseType, subDim] = decodeArrayType(subType)
+    return [baseType, (subDim.unshift(dim), subDim)]
+  } else {
+    return [subType, [dim]]
+  }
+}
+
+function foldVals(vals: Val[], dims: number[]): Val {
+  if (dims.length == 1) {
+    return vals
+  } else {
+    const result: Val[] = []
+    const chunkSize = vals.length / dims[0]
+    const chunkDims = dims.slice(1)
+    for (let i = 0; i < vals.length; i += chunkSize) {
+      const chunk = vals.slice(i, i + chunkSize)
+      result.push(foldVals(chunk, chunkDims))
+    }
+    return result
+  }
+}
+
+function _fromApiVal(vals: api.Val[], valIndex: number, tpe: string): [result: Val, nextIndex: number] {
+  if (vals.length === 0) {
+    throw new Error('Not enough Vals')
+  }
+
+  const firstVal = vals[valIndex]
+  if (tpe === 'Bool' && firstVal.type === tpe) {
+    return [firstVal.value as boolean, valIndex + 1]
+  } else if ((tpe === 'U256' || tpe === 'I256') && firstVal.type === tpe) {
+    return [decodeNumber256(firstVal.value as string), valIndex + 1]
+  } else if ((tpe === 'ByteVec' || tpe === 'Address') && firstVal.type === tpe) {
+    return [firstVal.value as string, valIndex + 1]
+  } else {
+    const [baseType, dims] = decodeArrayType(tpe)
+    const arraySize = dims.reduce((a, b) => a * b)
+    const nextIndex = valIndex + arraySize
+    const valsToUse = vals.slice(valIndex, nextIndex)
+    if (valsToUse.length == arraySize && valsToUse.every((val) => val.type === baseType)) {
+      const localVals = valsToUse.map((val) => fromApiVal(val, baseType))
+      return [foldVals(localVals, dims), nextIndex]
+    } else {
+      throw new Error(`Invalid array Val type: ${valsToUse}, ${tpe}`)
+    }
+  }
+}
+
+function fromApiVals(vals: api.Val[], types: string[]): Val[] {
+  let valIndex = 0
+  const result: Val[] = []
+  for (const currentType of types) {
+    const [val, nextIndex] = _fromApiVal(vals, valIndex, currentType)
+    result.push(val)
+    valIndex = nextIndex
+  }
+  return result
+}
+
+function fromApiVal(v: api.Val, tpe: string): Val {
+  if (v.type === 'Bool' && v.type === tpe) {
+    return v.value as boolean
+  } else if ((v.type === 'U256' || v.type === 'I256') && v.type === tpe) {
+    return decodeNumber256(v.value as string)
+  } else if ((v.type === 'ByteVec' || v.type === 'Address') && v.type === tpe) {
+    return v.value as string
+  } else {
+    throw new Error(`Invalid api.Val type: ${v}`)
+  }
+}
+
+export interface Asset {
+  alphAmount: Number256
+  tokens?: Token[]
+}
+
+export interface Token {
+  id: string
+  amount: Number256
+}
+
+function toApiToken(token: Token): api.Token {
+  return { id: token.id, amount: extractNumber256(token.amount) }
+}
+
+function fromApiToken(token: api.Token): Token {
+  return { id: token.id, amount: decodeNumber256(token.amount) }
+}
+
+function toApiAsset(asset: Asset): api.AssetState {
+  return {
+    alphAmount: extractNumber256(asset.alphAmount),
+    tokens: asset.tokens ? asset.tokens.map(toApiToken) : []
+  }
+}
+
+function fromApiAsset(asset: api.AssetState): Asset {
+  return {
+    alphAmount: decodeNumber256(asset.alphAmount),
+    tokens: asset.tokens ? asset.tokens.map(fromApiToken) : undefined
+  }
+}
+
+export interface InputAsset {
+  address: string
+  asset: Asset
+}
+
+export interface ContractState {
+  fileName: string
+  address: string
+  bytecode: string
+  codeHash: string
+  fields: Val[]
+  fieldTypes: string[]
+  asset: Asset
+}
+
+function toApiContractState(state: ContractState, address: string): api.ContractState {
+  return {
+    address: address,
+    bytecode: state.bytecode,
+    codeHash: state.codeHash,
+    fields: toApiFields(state.fields, state.fieldTypes),
+    asset: toApiAsset(state.asset)
+  }
+}
+
+function toApiFields(fields: Val[], fieldTypes: string[]): api.Val[] {
+  if (fields.length === fieldTypes.length) {
+    return fields.map((field, index) => toApiVal(field, fieldTypes[index]))
+  } else {
+    throw new Error(`Invalid number of fields: ${fields}`)
+  }
+}
+
+function toApiInputAsset(inputAsset: InputAsset): api.InputAsset {
+  return { address: inputAsset.address, asset: toApiAsset(inputAsset.asset) }
+}
+
+function toApiInputAssets(inputAssets?: InputAsset[]): api.InputAsset[] | undefined {
+  return inputAssets ? inputAssets.map(toApiInputAsset) : undefined
+}
+
+export interface TestContractParams {
+  group?: number // default 0
+  address?: string
+  initialFields?: Val[] // default no fields
+  initialAsset?: Asset // default 1 ALPH
+  testMethodIndex?: number // default 0
+  testArgs?: Val[] // default no arguments
+  existingContracts?: ContractState[] // default no existing contracts
+  inputAssets?: InputAsset[] // default no input asserts
+}
+
+type Event = ContractEvent | TxScriptEvent
+
+export interface ContractEvent {
+  blockHash: string
+  contractAddress: string
+  txId: string
+  name: string
+  fields: Val[]
+}
+
+export interface TxScriptEvent {
+  blockHash: string
+  txId: string
+  name: string
+  fields: Val[]
+}
+
+export interface TestContractResult {
+  returns: Val[]
+  gasUsed: number
+  contracts: ContractState[]
+  txOutputs: Output[]
+  events: Event[]
+}
+export declare type Output = AssetOutput | ContractOutput
+export interface AssetOutput extends Asset {
+  type: string
+  address: string
+  lockTime: number
+  additionalData: string
+}
+export interface ContractOutput {
+  type: string
+  address: string
+  alphAmount: Number256
+  tokens: Token[]
+}
+
+function fromApiOutput(output: api.Output): Output {
+  if (output.type === 'AssetOutput') {
+    const asset = output as api.AssetOutput
+    return {
+      type: 'AssetOutput',
+      address: asset.address,
+      alphAmount: decodeNumber256(asset.alphAmount),
+      tokens: asset.tokens.map(fromApiToken),
+      lockTime: asset.lockTime,
+      additionalData: asset.additionalData
+    }
+  } else if (output.type === 'ContractOutput') {
+    const asset = output as api.ContractOutput
+    return {
+      type: 'ContractOutput',
+      address: asset.address,
+      alphAmount: decodeNumber256(asset.alphAmount),
+      tokens: asset.tokens.map(fromApiToken)
+    }
+  } else {
+    throw new Error(`Unknown output type: ${output}`)
+  }
+}
+
+export interface DeployContractTransaction {
+  group: number
+  unsignedTx: string
+  txId: string
+  contractAddress: string
+}
+
+function fromApiDeployContractUnsignedTx(result: api.BuildContractDeployScriptTxResult): DeployContractTransaction {
+  return result
+}
+
+export interface BuildScriptTx {
+  alphAmount?: Number256
+  tokens?: Token[]
+  gas?: number
+  gasPrice?: Number256
+  utxosLimit?: number
+}
+
+export interface BuildScriptTxResult {
+  unsignedTx: string
+  txId: string
+  group: number
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -23,6 +23,7 @@ export * from './wallet'
 export * from './explorer'
 export * from './address'
 export * from './signer'
+export * from './contract'
 export * from './errors'
 export {
   formatAmountForDisplay,

--- a/lib/node.ts
+++ b/lib/node.ts
@@ -32,13 +32,13 @@ export class NodeClient extends Api<null> {
     toAddress: string,
     amount: string,
     lockTime?: number,
-    gasAmount?: number,
+    gas?: number,
     gasPrice?: string
   ) {
     return await this.transactions.postTransactionsBuild({
       fromPublicKey,
-      destinations: [{ address: toAddress, attoAlphAmount: amount, lockTime }],
-      gasAmount,
+      destinations: [{ address: toAddress, alphAmount: amount, lockTime }],
+      gas,
       gasPrice
     })
   }

--- a/lib/signer.ts
+++ b/lib/signer.ts
@@ -55,7 +55,7 @@ export class Signer {
     const signature = await this.sign(txHash)
     const params: api.SubmitTransaction = { unsignedTx: unsignedTx, signature: signature }
     const response = await this.client.transactions.postTransactionsSubmit(params)
-    return CliqueClient.convert(response)
+    return fromApiSubmissionResult(CliqueClient.convert(response))
   }
 }
 
@@ -63,4 +63,8 @@ export interface SubmissionResult {
   txId: string
   fromGroup: number
   toGroup: number
+}
+
+function fromApiSubmissionResult(result: api.TxResult): SubmissionResult {
+  return result
 }

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
   },
   "author": "Alephium dev <dev@alephium.org>",
   "config": {
-    "alephium_version": "1.4.1",
-    "explorer_backend_version": "1.7.0"
+    "alephium_version": "1.3.0",
+    "explorer_backend_version": "1.6.9"
   },
   "scripts": {
     "build": "rm -rf dist && npx tsc --build . && webpack",

--- a/test/contract-test.ts
+++ b/test/contract-test.ts
@@ -1,0 +1,114 @@
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { CliqueClient } from '../lib/clique'
+import { Signer } from '../lib/signer'
+import { Contract, Script, TestContractParams } from '../lib/contract'
+
+describe('contract', function () {
+  async function testSuite1() {
+    const client = new CliqueClient({ baseUrl: 'http://127.0.0.1:22973' })
+    await client.init(false)
+
+    const add = await Contract.from(client, 'add.ral')
+    const sub = await Contract.from(client, 'sub.ral')
+
+    const subTestAddress = Contract.randomAddress()
+    const subState = sub.toState([0], { alphAmount: BigInt('1000000000000000000') }, subTestAddress)
+    const testParams: TestContractParams = {
+      initialFields: [0],
+      testArgs: [subTestAddress, [2, 1]],
+      existingContracts: [subState]
+    }
+    const testResult = await add.test(client, 'add', testParams)
+    expect(testResult.returns).toEqual([[3, 1]])
+    expect(testResult.contracts[0].fileName).toEqual('sub.ral')
+    expect(testResult.contracts[0].fields).toEqual([1])
+    expect(testResult.contracts[1].fileName).toEqual('add.ral')
+    expect(testResult.contracts[1].fields).toEqual([3])
+    const events = testResult.events.sort((a, b) => a.name.localeCompare(b.name))
+    expect(events[0].name).toEqual('Add')
+    expect(events[0].fields).toEqual([2, 1])
+    expect(events[1].name).toEqual('Sub')
+    expect(events[1].fields).toEqual([2, 1])
+
+    const signer = Signer.testSigner(client)
+
+    const subDeployTx = await sub.transactionForDeployment(signer, [0])
+    expect(subDeployTx.group).toEqual(0)
+    const subSubmitResult = await signer.submitTransaction(subDeployTx.unsignedTx, subDeployTx.txId)
+    expect(subSubmitResult.fromGroup).toEqual(0)
+    expect(subSubmitResult.toGroup).toEqual(0)
+    expect(subSubmitResult.txId).toEqual(subDeployTx.txId)
+
+    const addDeployTx = await add.transactionForDeployment(signer, [0])
+    expect(addDeployTx.group).toEqual(0)
+    const addSubmitResult = await signer.submitTransaction(addDeployTx.unsignedTx, addDeployTx.txId)
+    expect(addSubmitResult.fromGroup).toEqual(0)
+    expect(addSubmitResult.toGroup).toEqual(0)
+    expect(addSubmitResult.txId).toEqual(addDeployTx.txId)
+
+    const subAddress = subDeployTx.contractAddress
+    const addAddress = addDeployTx.contractAddress
+    const main = await Script.from(client, 'main.ral', { addAddress: addAddress, subAddress: subAddress })
+
+    const mainScriptTx = await main.transactionForDeployment(signer)
+    expect(mainScriptTx.group).toEqual(0)
+    const mainSubmitResult = await signer.submitTransaction(mainScriptTx.unsignedTx, mainScriptTx.txId)
+    expect(mainSubmitResult.fromGroup).toEqual(0)
+    expect(mainSubmitResult.toGroup).toEqual(0)
+  }
+
+  async function testSuite2() {
+    const client = new CliqueClient({ baseUrl: 'http://127.0.0.1:22973' })
+    await client.init(false)
+
+    const greeter = await Contract.from(client, 'greeter.ral')
+
+    const testParams: TestContractParams = {
+      initialFields: [1]
+    }
+    const testResult = await greeter.test(client, 'greet', testParams)
+    expect(testResult.returns).toEqual([1])
+    expect(testResult.contracts[0].fileName).toEqual('greeter.ral')
+    expect(testResult.contracts[0].fields).toEqual([1])
+
+    const signer = Signer.testSigner(client)
+
+    const deployTx = await greeter.transactionForDeployment(signer, [1])
+    expect(deployTx.group).toEqual(0)
+    const submitResult = await signer.submitTransaction(deployTx.unsignedTx, deployTx.txId)
+    expect(submitResult.fromGroup).toEqual(0)
+    expect(submitResult.toGroup).toEqual(0)
+    expect(submitResult.txId).toEqual(deployTx.txId)
+
+    const greeterAddress = deployTx.contractAddress
+    const main = await Script.from(client, 'greeter-main.ral', { greeterAddress: greeterAddress })
+
+    const mainScriptTx = await main.transactionForDeployment(signer)
+    expect(mainScriptTx.group).toEqual(0)
+    const mainSubmitResult = await signer.submitTransaction(mainScriptTx.unsignedTx, mainScriptTx.txId)
+    expect(mainSubmitResult.fromGroup).toEqual(0)
+    expect(mainSubmitResult.toGroup).toEqual(0)
+  }
+
+  it('should test contracts', async () => {
+    await testSuite1()
+    await testSuite2()
+  })
+})

--- a/test/e2e-test.ts
+++ b/test/e2e-test.ts
@@ -1,0 +1,92 @@
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { CliqueClient } from '../lib/clique'
+import { walletImport } from '../lib/wallet'
+
+const mnemonic =
+  'pilot ignore adjust ritual fiscal educate judge paper senior erosion protect expose knife transfer slim stage credit candy menu source maze bonus baby cage'
+const baseUrl = 'http://127.0.0.1:22973'
+const recipientAddress = '12ngYCQq7QPGEHAZSKQh5Ej9U9HqwkQyYFpVpoqkDpcmM'
+const amount = '1000000000000000000'
+
+describe('E2E tests', () => {
+  let client = new CliqueClient()
+  const wallet = walletImport(mnemonic)
+
+  beforeAll(async () => {
+    client = new CliqueClient({ baseUrl })
+    await client.init(false)
+  })
+
+  it('can initialize client', () => {
+    expect(client.baseUrl).toEqual(baseUrl)
+  })
+
+  it('can create a simple transaction', async () => {
+    const { data, error } = await client.transactionCreate(wallet.address, wallet.publicKey, recipientAddress, amount)
+    expect(error).toBeNull()
+    expect(data.txId).toBeDefined()
+    expect(data.unsignedTx).toBeDefined()
+  })
+
+  it('can create a transaction with custom gas amount and price', async () => {
+    const gasAmount = 20001
+    const gasPrice = '100000010000'
+
+    const { data, error } = await client.transactionCreate(
+      wallet.address,
+      wallet.publicKey,
+      recipientAddress,
+      amount,
+      undefined,
+      gasAmount,
+      gasPrice
+    )
+    expect(error).toBeNull()
+    expect(data.gasAmount).toEqual(gasAmount)
+    expect(data.gasPrice).toEqual(gasPrice)
+  })
+
+  it('can create sweep/consolidation transactions', async () => {
+    const { data, error } = await client.transactionConsolidateUTXOs(wallet.publicKey, wallet.address, recipientAddress)
+    expect(error).toBeNull()
+    expect(data.unsignedTxs.length).toBeGreaterThan(0)
+  })
+
+  it('can sign transactions', async () => {
+    const { data } = await client.transactionCreate(wallet.address, wallet.publicKey, recipientAddress, amount)
+    const signature = client.transactionSign(data.txId, wallet.privateKey)
+    expect(signature).toBeDefined()
+  })
+
+  it('can verify signatures', async () => {
+    const { data } = await client.transactionCreate(wallet.address, wallet.publicKey, recipientAddress, amount)
+    const signature = client.transactionSign(data.txId, wallet.privateKey)
+    const isValid = client.transactionVerifySignature(data.txId, wallet.publicKey, signature)
+    expect(isValid).toBeTruthy()
+  })
+
+  it('can send transactions', async () => {
+    const { data } = await client.transactionCreate(wallet.address, wallet.publicKey, recipientAddress, amount)
+    const signature = client.transactionSign(data.txId, wallet.privateKey)
+    const result = await client.transactionSend(wallet.address, data.unsignedTx, signature)
+    expect(result.error).toBeNull()
+    expect(result.data.txId).toEqual(data.txId)
+  })
+})

--- a/test/node-test.ts
+++ b/test/node-test.ts
@@ -52,8 +52,8 @@ describe('node', function () {
     expect(client.transactions.postTransactionsBuild).toHaveBeenCalledTimes(1)
     expect(client.transactions.postTransactionsBuild).toHaveBeenLastCalledWith({
       fromPublicKey: 'fromPublicKey',
-      destinations: [{ address: 'toAddress', attoAlphAmount: 'amount', lockTime: undefined }],
-      gasAmount: 20000,
+      destinations: [{ address: 'toAddress', alphAmount: 'amount', lockTime: undefined }],
+      gas: 20000,
       gasPrice: '1000000000'
     })
     expect(transaction).toEqual({ data: transactionMockData.created })


### PR DESCRIPTION
I want to keep the passphrase-related changes of release `0.0.11`, but I don't want to include the API breaking changes. This PR removes the breaking API changes. I did that with:
```
git revert --no-commit db0a00e
git revert --no-commit 8f6d006
git revert --no-commit ac03232
git commit
```

Once this gets merged to `master` we can release `0.0.12`.

Once that's done, we can re-apply the breaking changes to `master` by merging PR https://github.com/alephium/js-sdk/pull/113 and release `0.0.13-rc.0`.

@LeeAlephium WDYT?