### PR TITLE
Add empty line before return statement rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,3 +1,21 @@
+/*
+Copyright 2018 - 2022 The Alephium Authors
+This file is part of the alephium project.
+
+The library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the library. If not, see <http://www.gnu.org/licenses/>.
+*/
+
 module.exports = {
   parser: '@typescript-eslint/parser',
   extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier', 'plugin:prettier/recommended'],

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -41,7 +41,9 @@ module.exports = {
           requireLast: false
         }
       }
-    ]
+    ],
+    // require empty line above return statements
+    'padding-line-between-statements': ['error', { blankLine: 'always', prev: '*', next: 'return' }]
   },
   env: {
     browser: true,

--- a/lib/address.ts
+++ b/lib/address.ts
@@ -24,6 +24,7 @@ export function addressToGroup(address: string, totalNumberOfGroups: number): nu
   const value = djb2(bytes) | 1
   const hash = toPosInt(xorByte(value))
   const group = hash % totalNumberOfGroups
+
   return group
 }
 
@@ -31,6 +32,7 @@ function xorByte(value: number): number {
   const byte0 = value >> 24
   const byte1 = value >> 16
   const byte2 = value >> 8
+
   return byte0 ^ byte1 ^ byte2 ^ value
 }
 

--- a/lib/clique.ts
+++ b/lib/clique.ts
@@ -79,17 +79,20 @@ export class CliqueClient extends Api<null> {
   getClientIndex(address: string) {
     if (this.clients.length === 0) throw new Error('No nodes in the clique')
     const group = utils.groupOfAddress(address)
+
     return group % this.clients.length
   }
 
   async getBalance(address: string) {
     const clientIndex = this.getClientIndex(address)
+
     return await this.clients[clientIndex].getBalance(address)
   }
 
   getWebSocket(node_i: number) {
     if (this.clique.nodes) {
       const node = this.clique.nodes[node_i]
+
       return new WebSocket('ws://' + node.address + ':' + node.wsPort + '/events')
     }
   }
@@ -104,16 +107,19 @@ export class CliqueClient extends Api<null> {
     gasPrice?: string
   ) {
     const clientIndex = this.getClientIndex(fromAddress)
+
     return await this.clients[clientIndex].transactionCreate(fromPublicKey, toAddress, amount, lockTime, gas, gasPrice)
   }
 
   async transactionConsolidateUTXOs(fromPublicKey: string, fromAddress: string, toAddress: string) {
     const clientIndex = this.getClientIndex(fromAddress)
+
     return await this.clients[clientIndex].transactionConsolidateUTXOs(fromPublicKey, toAddress)
   }
 
   async transactionSend(fromAddress: string, tx: string, signature: string) {
     const clientIndex = this.getClientIndex(fromAddress)
+
     return await this.clients[clientIndex].transactionSend(tx, signature)
   }
 
@@ -127,6 +133,7 @@ export class CliqueClient extends Api<null> {
   transactionVerifySignature(txHash: string, publicKey: string, signature: string) {
     try {
       const key = ec.keyFromPublic(publicKey, 'hex')
+
       return key.verify(txHash, utils.signatureDecode(ec, signature))
     } catch (error) {
       return false

--- a/lib/djb2.ts
+++ b/lib/djb2.ts
@@ -21,5 +21,6 @@ export default function djb2(bytes: Uint8Array) {
   for (let i = 0; i < bytes.length; i++) {
     hash = (hash << 5) + hash + (bytes[i] & 0xff)
   }
+
   return hash
 }

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -39,5 +39,6 @@ export const getHumanReadableError = (e: unknown, defaultErrorMessage: string) =
   const serverError = isHTTPError(e)
     ? e.error.detail || `(${e.status}${e.statusText && `: ${e.statusText}`}) ${e.error.message || ''}`
     : stringifiedError
+
   return `${defaultErrorMessage}${serverError && `: ${serverError}`}`
 }

--- a/lib/numbers.ts
+++ b/lib/numbers.ts
@@ -55,6 +55,7 @@ const removeTrailingZeros = (numString: string, minNumberOfDecimals?: number) =>
   if (indexOfPoint === -1) throw 'numString should contain decimal point'
 
   const numberOfDecimals = numStringWithoutTrailingZeros.length - 1 - indexOfPoint
+
   return numberOfDecimals < minNumberOfDecimals
     ? numStringWithoutTrailingZeros.concat(produceZeros(minNumberOfDecimals - numberOfDecimals))
     : numStringWithoutTrailingZeros
@@ -79,11 +80,13 @@ export const formatAmountForDisplay = (
       numNonDecimals > 0
         ? baseNumString.substring(0, numNonDecimals).concat('.', baseNumString.substring(numNonDecimals))
         : '0.'.concat(produceZeros(-numNonDecimals), baseNumString)
+
     return removeTrailingZeros(alphNumString, numberOfDecimalsToDisplay)
   }
 
   if (alphNum < 0.001) {
     const tinyAmountsMaxNumberDecimals = 5
+
     return removeTrailingZeros(alphNum.toFixed(tinyAmountsMaxNumberDecimals), minNumberOfDecimals)
   } else if (alphNum <= 1000000) {
     return addApostrophes(removeTrailingZeros(alphNum.toFixed(numberOfDecimalsToDisplay), minNumberOfDecimals))
@@ -144,6 +147,7 @@ export const convertSetToAlph = (amountInSet: bigint): string => {
     positionForDot > 0
       ? amountInSetStr.substring(0, positionForDot) + '.' + amountInSetStr.substring(positionForDot)
       : '0.' + produceZeros(NUM_OF_ZEROS_IN_QUINTILLION - amountInSetStr.length) + amountInSetStr
+
   return removeTrailingZeros(withDotAdded)
 }
 

--- a/lib/signer.ts
+++ b/lib/signer.ts
@@ -42,12 +42,14 @@ export class Signer {
     } else {
       const response = await this.client.wallets.getWalletsWalletNameAddressesAddress(this.walletName, this.address)
       this._publicKey = CliqueClient.convert(response).publicKey
+
       return this._publicKey
     }
   }
 
   async sign(hash: string): Promise<string> {
     const response = await this.client.wallets.postWalletsWalletNameSign(this.walletName, { data: hash })
+
     return CliqueClient.convert(response).signature
   }
 
@@ -55,6 +57,7 @@ export class Signer {
     const signature = await this.sign(txHash)
     const params: api.SubmitTransaction = { unsignedTx: unsignedTx, signature: signature }
     const response = await this.client.transactions.postTransactionsSubmit(params)
+
     return fromApiSubmissionResult(CliqueClient.convert(response))
   }
 }

--- a/lib/storage-browser.ts
+++ b/lib/storage-browser.ts
@@ -50,6 +50,7 @@ class BrowserStorage {
         xs.push(key.substring(prefixLen))
       }
     }
+
     return xs
   }
 }

--- a/lib/storage-node.ts
+++ b/lib/storage-node.ts
@@ -40,6 +40,7 @@ class NodeStorage {
     } catch (error) {
       throw new Error(`Unable to load wallet ${name}: ${error}`)
     }
+
     return JSON.parse(buffer.toString())
   }
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -37,6 +37,7 @@ export const signatureEncode = (ec: EC.ec, signature: EC.ec.Signature) => {
   const xs = new Uint8Array(r.byteLength + s.byteLength)
   xs.set(new Uint8Array(r), 0)
   xs.set(new Uint8Array(s), r.byteLength)
+
   return Buffer.from(xs).toString('hex')
 }
 
@@ -50,6 +51,7 @@ export const signatureDecode = (ec: EC.ec, signature: string) => {
   const s = new BN(sHex, 'hex')
   if (ec.n && s.cmp(ec.nh) < 1) {
     const decoded = { r: signature.slice(0, 64), s: sHex }
+
     return decoded
   } else {
     throw new Error('The signature is not normalized')
@@ -67,6 +69,7 @@ const xorByte = (intValue: number) => {
   const byte1 = (intValue >> 16) & 0xff
   const byte2 = (intValue >> 8) & 0xff
   const byte3 = intValue & 0xff
+
   return (byte0 ^ byte1 ^ byte2 ^ byte3) & 0xff
 }
 
@@ -99,6 +102,7 @@ const groupOfAddressBytes = (bytes: Uint8Array): number => {
   const hint = djb2(bytes) | 1
   const hash = xorByte(hint)
   const group = hash % TOTAL_NUMBER_OF_GROUPS
+
   return group
 }
 

--- a/lib/wallet.ts
+++ b/lib/wallet.ts
@@ -143,6 +143,7 @@ export const deriveNewAddressData = (
 
 export const walletGenerate = (passphrase?: string) => {
   const mnemonic = bip39.generateMnemonic(256)
+
   return getWalletFromMnemonic(mnemonic, passphrase)
 }
 
@@ -150,6 +151,7 @@ export const walletImport = (mnemonic: string, passphrase?: string) => {
   if (!bip39.validateMnemonic(mnemonic)) {
     throw new Error('Invalid seed phrase')
   }
+
   return getWalletFromMnemonic(mnemonic, passphrase)
 }
 
@@ -164,5 +166,6 @@ export const walletEncrypt = (password: string, mnemonic: string) => {
   const storedState = new StoredState({
     mnemonic
   })
+
   return encrypt(password, JSON.stringify(storedState))
 }


### PR DESCRIPTION
What do you think about this guys? I think it's better for readability. I think @mvaivre and I have been doing this all along, I thought it might be a good idea to make it official through our eslint config.

I'll change the base branch once the other PRs are merged.

Docs: https://eslint.org/docs/latest/rules/padding-line-between-statements