### PR TITLE
Fix formatting amount for display

### DIFF
--- a/lib/numbers.ts
+++ b/lib/numbers.ts
@@ -89,7 +89,12 @@ export const formatAmountForDisplay = (
 
     return removeTrailingZeros(alphNum.toFixed(tinyAmountsMaxNumberDecimals), minNumberOfDecimals)
   } else if (alphNum <= 1000000) {
-    return addApostrophes(removeTrailingZeros(alphNum.toFixed(numberOfDecimalsToDisplay), minNumberOfDecimals))
+    const amountWithRemovedTrailingZeros = removeTrailingZeros(
+      alphNum.toFixed(numberOfDecimalsToDisplay),
+      minNumberOfDecimals
+    )
+
+    return alphNum >= 1000 ? addApostrophes(amountWithRemovedTrailingZeros) : amountWithRemovedTrailingZeros
   }
 
   const tier = alphNum < 1000000000 ? 2 : alphNum < 1000000000000 ? 3 : 4

--- a/test/numbers-test.ts
+++ b/test/numbers-test.ts
@@ -79,6 +79,10 @@ it('Should keep full amount precision', () => {
     expect(formatAmountForDisplay(BigInt('1000000000000000000'), true, 3)).toEqual('1.000')
 })
 
+it('Should display a defined number of decimals', () => {
+  expect(formatAmountForDisplay(BigInt('20053549281751930708'), false, 5)).toEqual('20.05355')
+})
+
 it('should calucate the amount delta between the inputs and outputs of an address in a transaction', () => {
   expect(calAmountDelta(transactions.oneInputOneOutput, transactions.oneInputOneOutput.inputs[0].address)).toEqual(
     alph(BigInt(-50))


### PR DESCRIPTION
The apostrophe should not be there. This PR solves it

<img width="584" alt="image" src="https://user-images.githubusercontent.com/1579899/179489126-d0354397-817e-4993-9feb-e46d40d92780.png">
