### PR TITLE
Add isAddressValid util function

### DIFF
--- a/lib/address.ts
+++ b/lib/address.ts
@@ -39,3 +39,12 @@ function xorByte(value: number): number {
 function toPosInt(byte: number): number {
   return byte & 0xff
 }
+
+export const isAddressValid = (address: string) => {
+  if (!address) return false
+
+  const match = address.match(/^[1-9A-HJ-NP-Za-km-z]+$/)
+  const bytes = bs58.decode(address).slice(1)
+
+  return match !== null && match[0] === address && bytes.length >= 32
+}

--- a/lib/address.ts
+++ b/lib/address.ts
@@ -40,11 +40,5 @@ function toPosInt(byte: number): number {
   return byte & 0xff
 }
 
-export const isAddressValid = (address: string) => {
-  if (!address) return false
-
-  const match = address.match(/^[1-9A-HJ-NP-Za-km-z]+$/)
-  const bytes = bs58.decode(address).slice(1)
-
-  return match !== null && match[0] === address && bytes.length >= 32
-}
+export const isAddressValid = (address: string) =>
+  !!address && /^[1-9A-HJ-NP-Za-km-z]+$/.test(address) && bs58.decode(address).slice(1).length >= 32

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -16,5 +16,9 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
+import { BILLION } from './numbers'
+
 export const TOTAL_NUMBER_OF_GROUPS = 4
 export const MIN_UTXO_SET_AMOUNT = BigInt(1000000000000)
+export const MINIMAL_GAS_AMOUNT = 20000
+export const MINIMAL_GAS_PRICE = BigInt(BILLION * 100) // 100 nanoALPH for the first year to prevent DoS attacks

--- a/test/address-test.ts
+++ b/test/address-test.ts
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with the library. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { addressToGroup } from '../lib/address'
+import { addressToGroup, isAddressValid } from '../lib/address'
 
 describe('address', function () {
   it('should derive group', async () => {
@@ -43,5 +43,15 @@ describe('address', function () {
     check('15XyPNJuZ85wyUMs4mwn98LLPMjiwUSCuTmR74NuxpwXT', 0)
     check('1F6ssQRwH1p1omaoQR3eirFrycHC3mUr3Vw9pLcgEe33W', 1)
     check('19JtVnQ4YLcA9mWPafnLmtWarAjdaLR3d7R5RAUjxHbe1', 3)
+  })
+
+  it('is valid', async () => {
+    expect(isAddressValid('16sR3EMn2BdFgENRhz6N2TJ78nfaADdv3prKXUQMaB6m3')).toBeTruthy()
+    expect(isAddressValid('19XWyoWy6DjrRp7erWqPfBnh7HL1Sb2Ub8SVjux2d71Eb')).toBeTruthy()
+    expect(isAddressValid('1CsutTzw8WVhqr1PB6F1tYinuLihAsAm9FxE7rVkC3Z2u')).toBeTruthy()
+    expect(isAddressValid('1CwD52BrUj9e4WDJSZ7RXLU2A8us4ZFSmYBDKu98p7szi')).toBeTruthy()
+    expect(isAddressValid('1BHSQ8JMeYHZe2kj3KmLjuQCSM3mvzYjNutz14uRPbxZM')).toBeTruthy()
+    expect(isAddressValid('')).toBeFalsy()
+    expect(isAddressValid('123')).toBeFalsy()
   })
 })


### PR DESCRIPTION
I need to check for address validity in the mobile wallet, so I checked [what we do in the desktop wallet](https://github.com/alephium/desktop-wallet/blob/master/src/utils/addresses.ts#L37-L43), and moved the function in the SDK to be reused by the mobile wallet. When I added some tests I noticed that some weird addresses (ex: `123`) was passing the valitity tests. Then, @Lbqds told me that I should decode it and check that the bytes length is at least 32 bytes.

This PR adds the updated validity function to the SDK.