### PR TITLE
Fix exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alephium/sdk",
-  "version": "0.2.1",
+  "version": "0.2.2-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@alephium/sdk",
-      "version": "0.2.1",
+      "version": "0.2.2-rc.0",
       "license": "GPL",
       "dependencies": {
         "base-x": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alephium/sdk",
-  "version": "0.2.1",
+  "version": "0.2.2-rc.0",
   "description": "A JS/TS library to interact with the Alephium platform",
   "license": "GPL",
   "main": "dist/lib/index.js",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
   "browser": "dist/alephium.min.js",
   "types": "dist/lib/index.d.ts",
   "exports": {
-    ".": "./dist/lib/index.js",
+    ".": {
+      "browser": "./dist/alephium.min.js",
+      "default": "./dist/lib/index.js"
+    },
     "./api/alephium": "./dist/api/api-alephium.js",
     "./api/explorer": "./dist/api/api-explorer.js"
   },


### PR DESCRIPTION
This change was tested using the https://github.com/nop33/alephium-js-sdk-test-projects project. What was tested was:
- Node environment, both CJS and ESM
- Browser environment
- React Native environment

This solves https://github.com/alephium/explorer/issues/144

The problem was that the `exports` field was taking precedence over the `main` and `browser` fields. The solution to the problem was to add the following (see https://github.com/alephium/js-sdk/pull/132):

```json
"exports": {
    ".": {
      "browser": "./dist/alephium.min.js",
      "default": "./dist/lib/index.js"
    }
}
```

Based on the NodeJS docs:
> For new packages targeting the currently supported versions of Node.js, the "exports" field is recommended. For packages supporting Node.js 10 and below, the "main" field is required. If both "exports" and "main" are defined, the "exports" field takes precedence over "main" in supported versions of Node.js.
> 
> When writing a new package, it is recommended to use the "exports" field.

Even though removing `main` and `browser` and only leaving `exports` worked well when testing node and browser environments, it didn't work in React Native environment. So, the `main` and `browser` fields remain.

Related links:
- https://nodejs.org/api/packages.html#nodejs-packagejson-field-definitions
- https://docs.npmjs.com/cli/v9/configuring-npm/package-json#main
- https://webpack.js.org/guides/package-exports/#conditional-syntax
- https://medium.com/swlh/npm-new-package-json-exports-field-1a7d1f489ccf