### PR TITLE
💥 Rename AddressAndKeys to AddressKeyPair

### DIFF
--- a/test/address-test.ts
+++ b/test/address-test.ts
@@ -120,7 +120,7 @@ describe('address', function () {
     results = await discoverActiveAddresses(masterKey, client)
     expect(client.addressesActive.postAddressesActive).toBeCalledTimes(2)
     expect(results).toHaveLength(1)
-    expect(results.map((a) => a.address)).toContain(derivedAddresses.group0[4])
+    expect(results.map((a) => a.hash)).toContain(derivedAddresses.group0[4])
     mockedPostAddressesActive.mockClear()
 
     // Scenario 3:
@@ -153,7 +153,7 @@ describe('address', function () {
     results = await discoverActiveAddresses(masterKey, client)
     expect(client.addressesActive.postAddressesActive).toBeCalledTimes(4)
     expect(results).toHaveLength(3)
-    const addresses = results.map((a) => a.address)
+    const addresses = results.map((a) => a.hash)
     expect(addresses).toContain(derivedAddresses.group0[4])
     expect(addresses).toContain(derivedAddresses.group0[7])
     expect(addresses).toContain(derivedAddresses.group2[0])

--- a/test/wallet-test.ts
+++ b/test/wallet-test.ts
@@ -99,13 +99,13 @@ describe('Wallet', function () {
 
   describe('should derive a new address', () => {
     const masterKey = walletUtils.walletImport(wallets.wallets[0].mnemonic).masterKey
-    const { address: existingAddress, addressIndex: existingAddressIndex } = walletUtils.deriveNewAddressData(masterKey)
+    const { hash: existingAddress, index: existingAddressIndex } = walletUtils.deriveNewAddressData(masterKey)
 
     it('in a random group', () => {
       let newAddressData = walletUtils.deriveNewAddressData(masterKey)
-      expect(newAddressData.address).toEqual(existingAddress)
+      expect(newAddressData.hash).toEqual(existingAddress)
       newAddressData = walletUtils.deriveNewAddressData(masterKey, undefined, undefined, [existingAddressIndex])
-      expect(newAddressData.address).not.toEqual(existingAddress)
+      expect(newAddressData.hash).not.toEqual(existingAddress)
     })
 
     it('in a specific group', () => {
@@ -114,9 +114,9 @@ describe('Wallet', function () {
         const newAddressData = walletUtils.deriveNewAddressData(masterKey, validGroup, undefined, [
           existingAddressIndex
         ])
-        const groupOfNewAddress = addressToGroup(newAddressData.address, TOTAL_NUMBER_OF_GROUPS)
+        const groupOfNewAddress = addressToGroup(newAddressData.hash, TOTAL_NUMBER_OF_GROUPS)
         expect(groupOfNewAddress).toEqual(validGroup)
-        expect(newAddressData.address).not.toEqual(existingAddress)
+        expect(newAddressData.hash).not.toEqual(existingAddress)
       })
 
       const invalidGroups = [-1, TOTAL_NUMBER_OF_GROUPS, TOTAL_NUMBER_OF_GROUPS + 1, -0.1, 0.1, 1e18, -1e18]


### PR DESCRIPTION
Also rename `addressIndex` to `index` and `address` to `hash`.

@mvaivre This is a change that I wanted to do for a long time. It's a breaking change. I never liked the `AddressAndKeys` name. I also never liked the fact that its properties are named differently than the state of our apps (and I don't wanna change our apps state). Let me know what you think.

```ts
// Desktop + mobile wallet
type Address = {
  hash: string
  index: number
  publicKey: string
  privateKey: string
  ...
}
```

```ts
// js-sdk
type AddressAndKeys = {
  address: string
  addressIndex: number
  publicKey: string
  privateKey: string
}
```

PS: How about prefixing every commit that introduces breaking changes with a 💥 emoji to make the parsing of the commit history easier when releasing a new version and want to write a nice changelog?